### PR TITLE
Chore: update peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:release": "polkadot-ci-ghact-build"
   },
   "peerDependencies": {
-    "@polkadot/api": ">8"
+    "@polkadot/api": ">9"
   },
   "dependencies": {
     "@acala-network/api": "4.1.6-23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.0.5-6",
+  "version": "0.1.0",
   "description": "polkawallet bridge sdk",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Change Polkadot peer dependency to 9 or newer

Bump version of @interlay/bridge to 0.1.0