### PR TITLE
fix: dont use limited_reserve_transfer for kusama->kintsugi

### DIFF
--- a/src/adapters/polkadot.ts
+++ b/src/adapters/polkadot.ts
@@ -230,7 +230,7 @@ class BasePolkadotAdapter extends BaseCrossChainAdapter {
     }
 
     // to karura/acala
-    if (to === "acala" || to === "karura") {
+    if (to === "acala" || to === "karura" || to === "kintsugi") {
       const dst = { X1: { Parachain: toChain.paraChainId } };
       const acc = { X1: { AccountId32: { id: accountId, network: "Any" } } };
       const ass = [{ ConcreteFungible: { amount: amount.toChainData() } }];


### PR DESCRIPTION
Without this, the transfer fails with a misleading error message. The reason is that kusama doesn't realize our chain supports xcm v2, so it converts all messages to xcm v1 before sending it to us. It just happens that xcm v1 doesn't support the WeightLimit::Unlimited item, causing it to fail. The solution is to switch to an extrinsic that doesn't set an unlimited weight