### PR TITLE
Fix: add always-auth and registry-url params to npm github actions

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -12,7 +12,9 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                node-version-file: ".nvmrc"
+                  node-version-file: ".nvmrc"
+                  registry-url: "https://registry.npmjs.org"
+                  always-auth: true
             - run: corepack enable
             - run: yarn install
             - run: yarn build


### PR DESCRIPTION
Add `always-auth` and `registry-url` params for npm publish action to work.