### PR TITLE
Feat: Add xcm for INTR, IBTC from Interlay to Moonbeam

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "polkawallet bridge sdk",
   "main": "build/src/index.js",
   "typings": "build/src/index.d.ts",

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -39,6 +39,21 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     xcm: { fee: { token: "DOT", amount: "0" }, weightLimit: DEST_WEIGHT },
   },
   {
+    to: "moonbeam",
+    token: "INTR",
+    // todo: determine fee amount - current value is a copied value / best guess
+    xcm: {
+      fee: { token: "INTR", amount: "93240000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "moonbeam",
+    token: "IBTC",
+    // todo: determine fee amount - current value is a copied value / best guess
+    xcm: { fee: { token: "IBTC", amount: "9" }, weightLimit: DEST_WEIGHT },
+  },
+  {
     to: "statemint",
     token: "USDT",
     // todo: determine fee amount - current value is a placeholder

--- a/src/adapters/moonbeam.ts
+++ b/src/adapters/moonbeam.ts
@@ -19,6 +19,8 @@ export const moonbeamTokensConfig: Record<string, BasicToken> = {
   ACA: { name: "ACA", symbol: "ACA", decimals: 12, ed: "100000000000" },
   AUSD: { name: "AUSD", symbol: "AUSD", decimals: 12, ed: "100000000000" },
   LDOT: { name: "LDOT", symbol: "LDOT", decimals: 10, ed: "500000000" },
+  INTR: { name: "INTR", symbol: "INTR", decimals: 10, ed: "1000000000" },
+  IBTC: { name: "IBTC", symbol: "IBTC", decimals: 8, ed: "100" },
 };
 
 export const moonriverTokensConfig: Record<string, BasicToken> = {

--- a/src/bridge.spec.ts
+++ b/src/bridge.spec.ts
@@ -158,5 +158,8 @@ describe("Bridge sdk usage", () => {
 
     // interlay
     printBidirectionalTxs("interlay", "statemint", "USDT");
+    // no adapter available for tx originating from moonbeam (yet?)
+    printTx("interlay", "moonbeam", "INTR");
+    printTx("interlay", "moonbeam", "IBTC");
   });
 });


### PR DESCRIPTION
No reverse xcm yet, as we don't have an adapter for tx originating from moonbeam yet.