### PR TITLE
Chore: reduce logging verbosity

### DIFF
--- a/src/api-provider.spec.ts
+++ b/src/api-provider.spec.ts
@@ -1,7 +1,6 @@
-// import { firstValueFrom } from "rxjs";
-
+import { firstValueFrom } from "rxjs";
 import { ApiProvider } from "./api-provider";
-// import { ChainName } from "./configs";
+import { ChainName } from "./configs";
 
 describe("api-provider", () => {
   jest.setTimeout(30000);
@@ -9,50 +8,49 @@ describe("api-provider", () => {
   const provider = new ApiProvider("mainnet");
 
   test("connectFromChain should be ok", async () => {
-    console.log(provider);
-    //   const chains: ChainName[] = ["kusama", "karura", "polkadot", "acala"];
+      const chains: ChainName[] = ["kusama", "karura", "polkadot", "acala"];
 
-    //   expect(provider.getApi(chains[0])).toEqual(undefined);
-    //   expect(provider.getApi(chains[1])).toEqual(undefined);
+      expect(provider.getApi(chains[0])).toEqual(undefined);
+      expect(provider.getApi(chains[1])).toEqual(undefined);
 
-    //   const res = await firstValueFrom(
-    //     provider.connectFromChain(chains, {
-    //       karura: ["wss://karura.polkawallet.io"],
-    //     })
-    //   );
+      const res = await firstValueFrom(
+        provider.connectFromChain(chains, {
+          karura: ["wss://karura.polkawallet.io"],
+        })
+      );
 
-    //   expect(res.length).toEqual(chains.length);
+      expect(res.length).toEqual(chains.length);
 
-    //   expect(res[0]).toEqual(chains[0]);
-    //   expect(res[1]).toEqual(chains[1]);
-    //   expect(res[2]).toEqual(chains[2]);
-    //   expect(res[3]).toEqual(chains[3]);
+      expect(res[0]).toEqual(chains[0]);
+      expect(res[1]).toEqual(chains[1]);
+      expect(res[2]).toEqual(chains[2]);
+      expect(res[3]).toEqual(chains[3]);
 
-    //   expect(provider.getApi(chains[0])).toBeDefined();
-    //   expect(provider.getApi(chains[1])).toBeDefined();
+      expect(provider.getApi(chains[0])).toBeDefined();
+      expect(provider.getApi(chains[1])).toBeDefined();
 
-    //   expect(
-    //     (
-    //       await firstValueFrom(provider.getApi(chains[2]).rpc.system.chain())
-    //     ).toLowerCase()
-    //   ).toEqual(chains[2]);
-    //   expect(
-    //     (
-    //       await firstValueFrom(provider.getApi(chains[3]).rpc.system.chain())
-    //     ).toLowerCase()
-    //   ).toEqual(chains[3]);
+      expect(
+        (
+          await firstValueFrom(provider.getApi(chains[2]).rpc.system.chain())
+        ).toLowerCase()
+      ).toEqual(chains[2]);
+      expect(
+        (
+          await firstValueFrom(provider.getApi(chains[3]).rpc.system.chain())
+        ).toLowerCase()
+      ).toEqual(chains[3]);
 
-    //   setTimeout(async () => {
-    //     expect(
-    //       (
-    //         await provider.getApiPromise(chains[0]).rpc.system.chain()
-    //       ).toLowerCase()
-    //     ).toEqual(chains[0]);
-    //     expect(
-    //       (
-    //         await provider.getApiPromise(chains[1]).rpc.system.chain()
-    //       ).toLowerCase()
-    //     ).toEqual(chains[1]);
-    //   }, 1000);
+      setTimeout(async () => {
+        expect(
+          (
+            await provider.getApiPromise(chains[0]).rpc.system.chain()
+          ).toLowerCase()
+        ).toEqual(chains[0]);
+        expect(
+          (
+            await provider.getApiPromise(chains[1]).rpc.system.chain()
+          ).toLowerCase()
+        ).toEqual(chains[1]);
+      }, 1000);
   });
 });

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -36,7 +36,6 @@ export class ApiProvider {
     chainName: ChainName[],
     nodeList: Partial<Record<ChainName, string[]>> | undefined
   ) {
-    console.log(this.network);
     return combineLatest(
       chainName.map((chain) => {
         let nodes = (nodeList || {})[chain];
@@ -94,17 +93,13 @@ export class ApiProvider {
 
     const wsProvider = new WsProvider(nodes);
 
-    const isAcala = chainName === "acala" || chainName === "karura";
-    const option = isAcala
-      ? options({
-          provider: wsProvider,
-        })
-      : {
-          provider: wsProvider,
-        };
-    const promiseApi = ApiPromise.create(option);
+    const apiOptions = options({
+      provider: wsProvider,
+      noInitWarn: true,
+    });
+    const promiseApi = ApiPromise.create(apiOptions);
 
-    return ApiRx.create(option).pipe(
+    return ApiRx.create(apiOptions).pipe(
       map((api) => {
         // connect success
         if (api) {


### PR DESCRIPTION
Primarily by adding `noInitWarn` flag to get rid of warnings about non-decorated rpc apis for each adapter/connection.

Also reenabled a test that has been commented out previously.