### PR TITLE
Feat: future proof xtokens transfer

### DIFF
--- a/src/adapters/acala.ts
+++ b/src/adapters/acala.ts
@@ -23,7 +23,7 @@ import {
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
-import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
+import { supportsUnlimitedDestWeight } from "../utils/xtokens-dest-weight";
 
 const ACALA_DEST_WEIGHT = "5000000000";
 

--- a/src/adapters/acala.ts
+++ b/src/adapters/acala.ts
@@ -16,13 +16,14 @@ import { ISubmittableResult } from "@polkadot/types/types";
 
 import { BaseCrossChainAdapter } from "../base-chain-adapter";
 import { ChainName, chains } from "../configs";
-import { ApiNotFound } from "../errors";
+import { ApiNotFound, DestinationWeightNotFound } from "../errors";
 import {
   BalanceData,
   BasicToken,
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
+import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
 
 const ACALA_DEST_WEIGHT = "5000000000";
 
@@ -196,10 +197,15 @@ class BaseAcalaAdapter extends BaseCrossChainAdapter {
 
     const tokenFormSDK = this.wallet?.getToken(token);
     const toChain = chains[to];
-    const oldDestWeight = this.getDestWeight(token, to);
-    const useNewDestWeight =
-      this.api.tx.xTokens.transfer.meta.args[3].type.toString() ===
-      "XcmV2WeightLimit";
+
+    // use "Unlimited" if the xToken.transfer's fourth parameter version supports it
+    const destWeight = supportsUnlimitedDestWeight(this.api)
+      ? "Unlimited"
+      : this.getDestWeight(token, to);
+
+    if (destWeight === undefined) {
+      throw new DestinationWeightNotFound(this.chain.id, to, token);
+    }
 
     const accountId = this.api?.createType("AccountId32", address).toHex();
 
@@ -218,7 +224,7 @@ class BaseAcalaAdapter extends BaseCrossChainAdapter {
       tokenFormSDK?.toChainData() as any,
       amount.toChainData(),
       { V1: dst },
-      (useNewDestWeight ? "Unlimited" : oldDestWeight?.toString()) as any
+      destWeight
     );
   }
 }

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -19,7 +19,7 @@ import {
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
-import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
+import { supportsUnlimitedDestWeight } from "../utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "Unlimited";
 

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -8,13 +8,18 @@ import { ISubmittableResult } from "@polkadot/types/types";
 import { BalanceAdapter, BalanceAdapterConfigs } from "../balance-adapter";
 import { BaseCrossChainAdapter } from "../base-chain-adapter";
 import { ChainName, chains } from "../configs";
-import { ApiNotFound, CurrencyNotFound } from "../errors";
+import {
+  ApiNotFound,
+  CurrencyNotFound,
+  DestinationWeightNotFound,
+} from "../errors";
 import {
   BalanceData,
   BasicToken,
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
+import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "Unlimited";
 
@@ -193,6 +198,15 @@ class BaseBifrostAdapter extends BaseCrossChainAdapter {
       throw new CurrencyNotFound(token);
     }
 
+    // use "Unlimited" if the xToken.transfer's fourth parameter version supports it
+    const destWeight = supportsUnlimitedDestWeight(this.api)
+      ? "Unlimited"
+      : this.getDestWeight(token, to);
+
+    if (destWeight === undefined) {
+      throw new DestinationWeightNotFound(this.chain.id, to, token);
+    }
+
     return this.api.tx.xTokens.transfer(
       tokenId,
       amount.toChainData(),
@@ -207,8 +221,7 @@ class BaseBifrostAdapter extends BaseCrossChainAdapter {
           },
         },
       },
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.getDestWeight(token, to)!.toString()
+      destWeight
     );
   }
 }

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -8,18 +8,13 @@ import { ISubmittableResult } from "@polkadot/types/types";
 import { BalanceAdapter, BalanceAdapterConfigs } from "../balance-adapter";
 import { BaseCrossChainAdapter } from "../base-chain-adapter";
 import { ChainName, chains } from "../configs";
-import {
-  ApiNotFound,
-  CurrencyNotFound,
-  DestinationWeightNotFound,
-} from "../errors";
+import { ApiNotFound, CurrencyNotFound } from "../errors";
 import {
   BalanceData,
   BasicToken,
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
-import { supportsUnlimitedDestWeight } from "../utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "Unlimited";
 
@@ -198,15 +193,6 @@ class BaseBifrostAdapter extends BaseCrossChainAdapter {
       throw new CurrencyNotFound(token);
     }
 
-    // use "Unlimited" if the xToken.transfer's fourth parameter version supports it
-    const destWeight = supportsUnlimitedDestWeight(this.api)
-      ? "Unlimited"
-      : this.getDestWeight(token, to);
-
-    if (destWeight === undefined) {
-      throw new DestinationWeightNotFound(this.chain.id, to, token);
-    }
-
     return this.api.tx.xTokens.transfer(
       tokenId,
       amount.toChainData(),
@@ -221,7 +207,7 @@ class BaseBifrostAdapter extends BaseCrossChainAdapter {
           },
         },
       },
-      destWeight
+      this.getDestWeight(token, to) || "Unlimited"
     );
   }
 }

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -20,7 +20,7 @@ import {
   CrossChainTransferParams,
 } from "../types";
 import { isChainEqual } from "../utils/is-chain-equal";
-import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
+import { supportsUnlimitedDestWeight } from "../utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "180000000000";
 

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -20,6 +20,7 @@ import {
   CrossChainTransferParams,
 } from "../types";
 import { isChainEqual } from "../utils/is-chain-equal";
+import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "180000000000";
 
@@ -323,11 +324,9 @@ class BaseInterlayAdapter extends BaseCrossChainAdapter {
     }
 
     // use "Unlimited" if the xToken.transfer's fourth parameter version supports it
-    const destWeight =
-      this.api.tx.xTokens.transfer.meta.args[3].type.toString() ===
-      "XcmV2WeightLimit"
-        ? "Unlimited"
-        : this.getDestWeight(token, to);
+    const destWeight = supportsUnlimitedDestWeight(this.api)
+      ? "Unlimited"
+      : this.getDestWeight(token, to);
 
     if (destWeight === undefined) {
       throw new DestinationWeightNotFound(this.chain.id, to, token);

--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -9,18 +9,13 @@ import { ISubmittableResult } from "@polkadot/types/types";
 import { BalanceAdapter, BalanceAdapterConfigs } from "../balance-adapter";
 import { BaseCrossChainAdapter } from "../base-chain-adapter";
 import { ChainName, chains } from "../configs";
-import {
-  ApiNotFound,
-  CurrencyNotFound,
-  DestinationWeightNotFound,
-} from "../errors";
+import { ApiNotFound, CurrencyNotFound } from "../errors";
 import {
   BalanceData,
   BasicToken,
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
-import { supportsUnlimitedDestWeight } from "../utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "Unlimited";
 
@@ -243,15 +238,6 @@ class BaseParallelAdapter extends BaseCrossChainAdapter {
       throw new CurrencyNotFound(token);
     }
 
-    // use "Unlimited" if the xToken.transfer's fourth parameter version supports it
-    const destWeight = supportsUnlimitedDestWeight(this.api)
-      ? "Unlimited"
-      : this.getDestWeight(token, to);
-
-    if (destWeight === undefined) {
-      throw new DestinationWeightNotFound(this.chain.id, to, token);
-    }
-
     return this.api.tx.xTokens.transfer(
       tokenId,
       amount.toChainData(),
@@ -266,7 +252,7 @@ class BaseParallelAdapter extends BaseCrossChainAdapter {
           },
         },
       },
-      destWeight
+      this.getDestWeight(token, to) || "Unlimited"
     );
   }
 }

--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -20,7 +20,7 @@ import {
   CrossChainRouterConfigs,
   CrossChainTransferParams,
 } from "../types";
-import { supportsUnlimitedDestWeight } from "src/utils/xtokens-dest-weight";
+import { supportsUnlimitedDestWeight } from "../utils/xtokens-dest-weight";
 
 const DEST_WEIGHT = "Unlimited";
 

--- a/src/bridge.spec.ts
+++ b/src/bridge.spec.ts
@@ -7,7 +7,7 @@ import { Bridge } from "./index";
 import { KintsugiAdapter, InterlayAdapter } from "./adapters/interlay";
 import { FN } from "./types";
 import { KusamaAdapter, PolkadotAdapter } from "./adapters/polkadot";
-import { StatemintAdapter } from "./adapters/statemint";
+import { StatemineAdapter, StatemintAdapter } from "./adapters/statemint";
 import { HeikoAdapter } from "./adapters/parallel";
 import { KaruraAdapter } from "./adapters/acala";
 import { BifrostAdapter } from "./adapters/bifrost";
@@ -27,6 +27,7 @@ describe.skip("Bridge sdk usage", () => {
     kintsugi: new KintsugiAdapter(),
     karura: new KaruraAdapter(),
     statemint: new StatemintAdapter(),
+    statemine: new StatemineAdapter(),
     heiko: new HeikoAdapter(),
     bifrost: new BifrostAdapter(),
   };

--- a/src/utils/xtokens-dest-weight.ts
+++ b/src/utils/xtokens-dest-weight.ts
@@ -1,0 +1,10 @@
+import { AnyApi } from "@acala-network/sdk-core";
+
+/**
+ * Returns whether xToken.transfer's fourth parameter (destination weight)
+ * supports a destination weight of "Unlimited".
+ * @param api The api of which to check the pallet
+ * @returns true if "Unlimited" is supported, false otherwise
+ */
+export const supportsUnlimitedDestWeight = (api: AnyApi): boolean =>
+  api.tx.xTokens.transfer.meta.args[3].type.toString() === "XcmV2WeightLimit";


### PR DESCRIPTION
Resolves #59 

Use "Unlimited" as destination weight for `xTokens.transfer` if supported, otherwise use existing format of a numeric (u64) destination weight as defined in the adapters' configurations.