### PR TITLE
fix: fees and eds

### DIFF
--- a/src/adapters/acala.ts
+++ b/src/adapters/acala.ts
@@ -60,8 +60,8 @@ export const karuraRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "kintsugi",
     token: "KBTC",
     xcm: {
-      // local tests in chopsticks indicate fees are around 123 (atomic units)
-      fee: { token: "KBTC", amount: "200" },
+      // local tests in chopsticks indicate fees are 107 satoshi
+      fee: { token: "KBTC", amount: "1070" },
       weightLimit: ACALA_DEST_WEIGHT,
     },
   },

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -106,7 +106,7 @@ export const kintsugiRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     token: "KBTC",
     xcm: {
       // from local tests on choptsicks: actual fees sat around 103
-      fee: { token: "KBTC", amount: "200" },
+      fee: { token: "KBTC", amount: "1030" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/parallel.ts
+++ b/src/adapters/parallel.ts
@@ -36,14 +36,8 @@ export const heikoRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "kintsugi",
     token: "KBTC",
     xcm: {
-      // estimated fee calculated from:
-      // ksm_per_sec = ~233_100_000_000
-      // kint_per_sec = (ksm_per_second * 4) / 3 = 310_800_000_000
-      // xcm_secs = ~(247_189_333 / kint_per_sec) ... calculated using a recent kint transaction
-      // kbtc_per_sec = ksm_per_sec / 1_500_000 ... see https://github.com/interlay/interbtc/blob/18efc1e9194a8591713b9885799a6deb6c0392f2/parachain/runtime/kintsugi/src/xcm_config.rs#L104
-      // estimated kbtc fee = kbtc_per_sec * xcm_secs = ~123.6
-      // local tests with chopsticks confirmed that value
-      fee: { token: "KBTC", amount: "200" },
+      // chopsticks tests indicate fees are 107
+      fee: { token: "KBTC", amount: "1070" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/polkadot.ts
+++ b/src/adapters/polkadot.ts
@@ -45,7 +45,7 @@ const polkadotTokensConfig: Record<string, Record<string, BasicToken>> = {
     DOT: { name: "DOT", symbol: "DOT", decimals: 10, ed: "10000000000" },
   },
   kusama: {
-    KSM: { name: "KSM", symbol: "KSM", decimals: 12, ed: "79999999" },
+    KSM: { name: "KSM", symbol: "KSM", decimals: 12, ed: "333333333" },
   },
 };
 


### PR DESCRIPTION
Output from testing script prior to this change:

```
Testing KBTC transfer from karura to kintsugi... WARN
⚠️ Fees need to be increased in config. The actual fees are 0.00000107 (= 107 plank). Fee overestimation factor was 1.86915887 - we want at least 2.0
Testing KBTC transfer from kintsugi to heiko... WARN
⚠️ Fees need to be increased in config. The actual fees are 0.00000103 (= 103 plank). Fee overestimation factor was 1.94174757 - we want at least 2.0
Testing KBTC transfer from heiko to kintsugi... WARN
⚠️ Fees need to be increased in config. The actual fees are 0.00000107 (= 107 plank). Fee overestimation factor was 1.86915887 - we want at least 2.0
```

I set a 10x margin for each of these.

Also the existential deposit on kusama was too low. The on-chain info:
```
const balances.existentialDeposit: u128

333,333,333
```