### PR TITLE
Fix: broken build output paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@open-web3/dev-config/config/tsconfig.json",
-  "exclude": ["build/**/*", "**/build/**/*"],
+  "exclude": ["build/**/*", "**/build/**/*", "scripts/**/*"],
   "compilerOptions": {
     "target": "es2019",
     "module": "CommonJS",


### PR DESCRIPTION
Build output paths changed after adding `scripts` folder - introducing subfolder `src` and `scripts`. Previously the build folder contained `src` contents directly. 

This fixes the paths again by ignoring `scripts` folder for build output.