### PR TITLE
Fix: bifrost xtokens transfer multilocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",


### PR DESCRIPTION
Updating Bifrost adapter to utilize V3 xcm multilocations instead of V1 when required.

Tested VKSM transactions:
- ✅ Kintsugi -> Bifrost. Actual fees are similar to before, no change to fee estimates
- ✅ Bifrost -> Kintsugi. Actual fees are identical to before, no change to fee estimates

Extrinsics used for chopsticks tests (from Alice to Alice):
Kintsugi -> Bifrost
```
0x5e00010500000000e40b5402000000000000000000000001010200451f0100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d00
```

Bifrost -> Kintsugi
```
0x4600010400e40b5402000000000000000000000003010200b1200100d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d00
```