### PR TITLE
Fix: Remove frozen amount from available balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -239,16 +239,28 @@ class InterlayBalanceAdapter extends BalanceAdapter {
 
     return this.storages.assets(address, tokenId).observable.pipe(
       map((balance) => {
-        const amount = FN.fromInner(
+        const free = FN.fromInner(
           balance.free?.toString() || "0",
           this.getToken(token).decimals
         );
 
+        const frozen = FN.fromInner(
+          balance.frozen?.toString() || "0",
+          this.getToken(token).decimals
+        );
+
+        const reserved = FN.fromInner(
+          balance.reserved?.toString() || "0",
+          this.getToken(token).decimals
+        );
+
+        const available = free.sub(frozen);
+
         return {
-          free: amount,
-          locked: new FN(0),
-          reserved: new FN(0),
-          available: amount,
+          free,
+          locked: frozen,
+          reserved,
+          available,
         };
       })
     );


### PR DESCRIPTION
Remove frozen from free amount to get the correct available amount on the Interlay adapter.