### PR TITLE
Refactor: Auto identify test cases for chopsticks

### DIFF
--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   chopsticks_kintsugi_test:

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   chopsticks_kintsugi_test:

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -8,8 +8,7 @@ import { HydraAdapter } from "../src/adapters/hydradx";
 import { AcalaAdapter } from "../src/adapters/acala";
 import { ParallelAdapter } from "../src/adapters/parallel";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
-import { ChainName } from "../src/configs";
-import { runTestCasesAndExit } from "./chopsticks-test";
+import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
 
 main().catch((err) => {
     console.log("Error thrown by script:");
@@ -35,20 +34,10 @@ async function main(): Promise<void> {
         polkadot:   { adapter: new PolkadotAdapter(),   endpoints: ['ws://127.0.0.1:8005'] },
     };
 
-    const testCases = [
-        ["polkadot", "DOT"],
-        ["statemint", "USDT"],
-        ["hydra", "IBTC"],
-        ["acala", "IBTC"],
-        ["acala", "INTR"],
-        // ["astar", "IBTC"],
-        // ["astar", "INTR"],
-        ["parallel", "IBTC"],
-        ["parallel", "INTR"],
-    ].flatMap(([targetChain, token]) => [
-        {from: "interlay" as ChainName, to: targetChain as ChainName, token}, 
-        {from: targetChain as ChainName, to: "interlay" as ChainName, token}
-    ]); // bidirectional testing
+    const filterCases: Partial<RouterTestCase>[] = [
+        {from: "astar"},
+        {to: "astar"},
+    ];
 
-    await runTestCasesAndExit(adaptersEndpoints, testCases);
+    await runTestCasesAndExit(adaptersEndpoints, filterCases);
 }

--- a/scripts/kintsugi-chopsticks-test.ts
+++ b/scripts/kintsugi-chopsticks-test.ts
@@ -1,14 +1,13 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* tslint:disable:no-unused-variable */
-import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
-import { ChainName } from "../src/configs";
-import { KintsugiAdapter } from "../src/adapters/interlay";
+import { KaruraAdapter } from "../src/adapters/acala";
 import { BifrostAdapter } from "../src/adapters/bifrost";
+import { KintsugiAdapter } from "../src/adapters/interlay";
+import { HeikoAdapter } from "../src/adapters/parallel";
 import { KusamaAdapter } from "../src/adapters/polkadot";
 import { StatemineAdapter } from "../src/adapters/statemint";
-import { KaruraAdapter } from "../src/adapters/acala";
-import { HeikoAdapter } from "../src/adapters/parallel";
+import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
 import { runTestCasesAndExit } from "./chopsticks-test";
 
 main().catch((err) => {
@@ -31,19 +30,5 @@ async function main(): Promise<void> {
         kusama:     { adapter: new KusamaAdapter(),     endpoints: ['ws://127.0.0.1:8005'] },
     };
 
-    const testCases = [
-        ["bifrost", "VKSM"],
-        ["kusama", "KSM"], 
-        ["karura", "KBTC"],
-        ["karura", "KINT"],
-        ["karura", "LKSM"],
-        ["statemine", "USDT"],
-        ["heiko", "KINT"],
-        ["heiko", "KBTC"],
-    ].flatMap(([targetChain, token]) => [
-        {from: "kintsugi" as ChainName, to: targetChain as ChainName, token}, 
-        {from: targetChain as ChainName, to: "kintsugi" as ChainName, token}
-    ]); // bidirectional testing
-
-    await runTestCasesAndExit(adaptersEndpoints, testCases);
+    await runTestCasesAndExit(adaptersEndpoints);
 }


### PR DESCRIPTION
Identify available to/from routers and tokens to run chopsticks tests against, and apply filter to skip test cases if a filter is provided.