### PR TITLE
fix: check for xcm v3 argument in xtokens.transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/utils/xtokens-helper.ts
+++ b/src/utils/xtokens-helper.ts
@@ -36,7 +36,8 @@ const buildV1orV3Destination = (
 };
 
 const supportsUnlimitedDestWeight = (api: AnyApi): boolean =>
-  api.tx.xTokens.transfer.meta.args[3].type.toString() === "XcmV2WeightLimit";
+  api.tx.xTokens.transfer.meta.args[3].type.toString() === "XcmV2WeightLimit" ||
+  api.tx.xTokens.transfer.meta.args[3].type.toString() === "XcmV3WeightLimit";
 
 export const xTokensHelper = {
   transfer: (


### PR DESCRIPTION
We need this for our next runtime upgrade