### PR TITLE
Chore: use derived balance for polkadot, kusama

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/adapters/polkadot.ts
+++ b/src/adapters/polkadot.ts
@@ -3,6 +3,7 @@ import { AnyApi, FixedPointNumber as FN } from "@acala-network/sdk-core";
 import { combineLatest, map, Observable } from "rxjs";
 
 import { SubmittableExtrinsic } from "@polkadot/api/types";
+import { DeriveBalancesAll } from "@polkadot/api-derive/balances/types";
 import { ISubmittableResult } from "@polkadot/types/types";
 
 import { BalanceAdapter, BalanceAdapterConfigs } from "../balance-adapter";
@@ -53,20 +54,11 @@ const polkadotTokensConfig: Record<string, Record<string, BasicToken>> = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const createBalanceStorages = (api: AnyApi) => {
-  // TODO: this works with polkadot/api 9.10.2, remember to return to this after upgrade
-  // return {
-  //   balances: (address: string) =>
-  //     Storage.create<DeriveBalancesAll>({
-  //       api,
-  //       path: "derive.balances.all",
-  //       params: [address],
-  //     }),
-  // };
   return {
     balances: (address: string) =>
-      Storage.create<any>({
+      Storage.create<DeriveBalancesAll>({
         api,
-        path: "query.system.account",
+        path: "derive.balances.all",
         params: [address],
       }),
   };
@@ -91,26 +83,16 @@ class PolkadotBalanceAdapter extends BalanceAdapter {
       throw new CurrencyNotFound(token);
     }
 
-    // TODO: remember to change back once we upgrade to polkadot 9.10.2 or higher.
     return storage.observable.pipe(
-      map((data) => {
-        const free = FN.fromInner(data.data.free.toString(), this.decimals);
-        const locked = FN.fromInner(
-          data.data.miscFrozen.toString(),
+      map((data) => ({
+        free: FN.fromInner(data.freeBalance.toString(), this.decimals),
+        locked: FN.fromInner(data.lockedBalance.toString(), this.decimals),
+        reserved: FN.fromInner(data.reservedBalance.toString(), this.decimals),
+        available: FN.fromInner(
+          data.availableBalance.toString(),
           this.decimals
-        );
-        const reserved = FN.fromInner(
-          data.data.reserved.toString(),
-          this.decimals
-        );
-        const available = free.sub(locked);
-        return {
-          free,
-          locked,
-          reserved,
-          available,
-        };
-      })
+        ),
+      }))
     );
   }
 }

--- a/src/adapters/polkadot.ts
+++ b/src/adapters/polkadot.ts
@@ -1,9 +1,9 @@
-import { Storage } from "@acala-network/sdk/utils/storage";
 import { AnyApi, FixedPointNumber as FN } from "@acala-network/sdk-core";
-import { combineLatest, map, Observable } from "rxjs";
+import { Storage } from "@acala-network/sdk/utils/storage";
+import { Observable, combineLatest, map } from "rxjs";
 
-import { SubmittableExtrinsic } from "@polkadot/api/types";
 import { DeriveBalancesAll } from "@polkadot/api-derive/balances/types";
+import { SubmittableExtrinsic } from "@polkadot/api/types";
 import { ISubmittableResult } from "@polkadot/types/types";
 
 import { BalanceAdapter, BalanceAdapterConfigs } from "../balance-adapter";


### PR DESCRIPTION
Revert previous changes, and use `derive.balances.all` storage instead of `query.system.account` to find an account's balance on Polkadot and Kusama.