### PR TITLE
fix: return fallback estimate if paymentInfo is unavailable

### DIFF
--- a/src/adapters/interlay.spec.ts
+++ b/src/adapters/interlay.spec.ts
@@ -3,9 +3,9 @@ import { firstValueFrom } from "rxjs";
 import { ApiProvider } from "../api-provider";
 import { chains, ChainName } from "../configs";
 import { Bridge } from "..";
-import { PolkadotAdapter } from "./polkadot";
+import { PolkadotAdapter, KusamaAdapter } from "./polkadot";
 import { InterlayAdapter, KintsugiAdapter } from "./interlay";
-import { StatemintAdapter } from "./statemint";
+import { StatemineAdapter, StatemintAdapter } from "./statemint";
 import { AcalaAdapter, KaruraAdapter } from "./acala";
 import { HeikoAdapter, ParallelAdapter } from "./parallel";
 import { buildTestTxWithConfigData } from "../utils/shared-spec-methods";
@@ -72,7 +72,7 @@ describe.skip("interlay-adapter should work", () => {
   }
 
   test("connect kintsugi to do xcm", async () => {
-    const fromChains = ["kintsugi", "karura", "heiko", "bifrost"] as ChainName[];
+    const fromChains = ["kintsugi", "karura", "heiko", "bifrost", "statemine", "kusama"] as ChainName[];
 
     await connect(fromChains);
 
@@ -80,14 +80,18 @@ describe.skip("interlay-adapter should work", () => {
     const karura = new KaruraAdapter();
     const heiko = new HeikoAdapter();
     const bifrost = new BifrostAdapter();
+    const statemine = new StatemineAdapter();
+    const kusama = new KusamaAdapter();
 
     await kintsugi.setApi(provider.getApi(fromChains[0]));
     await karura.setApi(provider.getApi(fromChains[1]));
     await heiko.setApi(provider.getApi(fromChains[2]));
     await bifrost.setApi(provider.getApi(fromChains[3]));
+    await statemine.setApi(provider.getApi(fromChains[4]));
+    await kusama.setApi(provider.getApi(fromChains[5]));
 
     const bridge = new Bridge({
-      adapters: [kintsugi, karura, heiko, bifrost],
+      adapters: [kintsugi, karura, heiko, bifrost, statemine, kusama],
     });
 
     // expected destinations: 1 (heiko, karura)
@@ -126,6 +130,9 @@ describe.skip("interlay-adapter should work", () => {
     await runMyTestSuite(testAccount, bridge, "kintsugi", "karura", "KBTC");
     await runMyTestSuite(testAccount, bridge, "kintsugi", "karura", "LKSM");
     await runMyTestSuite(testAccount, bridge, "kintsugi", "bifrost", "VKSM");
+    await runMyTestSuite(testAccount, bridge, "kintsugi", "statemine", "USDT");
+    await runMyTestSuite(testAccount, bridge, "kintsugi", "kusama", "KSM");
+
   });
 
   test("connect interlay to do xcm", async () => {

--- a/src/base-chain-adapter.ts
+++ b/src/base-chain-adapter.ts
@@ -231,6 +231,15 @@ export abstract class BaseCrossChainAdapter {
   public estimateTxFee(params: CrossChainTransferParams) {
     let tx = this.createTx({ ...params });
 
+    if (!tx.hasPaymentInfo) {
+      // TODO: remove when no longer needed
+      // workaround to have at least some fee estimate if paymentInfo is not available
+      // return 0.01 UNIT as best guesstimate
+      const token = this.getNativeToken();
+      const fallbackFeeEstimate = 10 ** (token.decimals - 2);
+      return from(fallbackFeeEstimate.toString());
+    }
+
     if (this.api?.type === "rxjs") {
       tx = tx as SubmittableExtrinsic<"rxjs", ISubmittableResult>;
 


### PR DESCRIPTION
Temporary fix to have some fee estimate even if `tx.paymentInfo` is not available in polkadot.js