### PR TITLE
fix: enable astar tests and fix astar ibtc fee

### DIFF
--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -68,6 +68,7 @@ jobs:
               --parachain=configs/statemint.yml \
               --parachain=configs/hydradx.yml \
               --parachain=configs/acala.yml \
+              --parachain=configs/astar.yml \
               --parachain=configs/parallel.yml &
             cd -
 

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -7,6 +7,7 @@ import { StatemintAdapter } from "../src/adapters/statemint";
 import { HydraAdapter } from "../src/adapters/hydradx";
 import { AcalaAdapter } from "../src/adapters/acala";
 import { ParallelAdapter } from "../src/adapters/parallel";
+import { AstarAdapter } from "../src/adapters/astar";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
 import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
 
@@ -26,18 +27,12 @@ async function main(): Promise<void> {
         statemint:  { adapter: new StatemintAdapter(),  endpoints: ['ws://127.0.0.1:8001'] },
         hydra:      { adapter: new HydraAdapter(),      endpoints: ['ws://127.0.0.1:8002'] },
         acala:      { adapter: new AcalaAdapter(),      endpoints: ['ws://127.0.0.1:8003'] },
-        // temporarily disable astar until cause for rpc errors has been found
-        // astar:      { adapter: new AstarAdapter(),      endpoints: ['ws://127.0.0.1:8004'] },
-        // parallel:   { adapter: new ParallelAdapter(),   endpoints: ['ws://127.0.0.1:8005'] },
-        // polkadot:   { adapter: new PolkadotAdapter(),   endpoints: ['ws://127.0.0.1:8006'] },
-        parallel:   { adapter: new ParallelAdapter(),   endpoints: ['ws://127.0.0.1:8004'] },
-        polkadot:   { adapter: new PolkadotAdapter(),   endpoints: ['ws://127.0.0.1:8005'] },
+        astar:      { adapter: new AstarAdapter(),      endpoints: ['ws://127.0.0.1:8004'] },
+        parallel:   { adapter: new ParallelAdapter(),   endpoints: ['ws://127.0.0.1:8005'] },
+        polkadot:   { adapter: new PolkadotAdapter(),   endpoints: ['ws://127.0.0.1:8006'] },
     };
 
-    const filterCases: Partial<RouterTestCase>[] = [
-        {from: "astar"},
-        {to: "astar"},
-    ];
+    const filterCases: Partial<RouterTestCase>[] = [];
 
     await runTestCasesAndExit(adaptersEndpoints, filterCases);
 }

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -47,9 +47,8 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {
     to: "astar",
     token: "IBTC",
-    // from recent xcm transfer: fee = 0 : https://interlay.subscan.io/xcm_message/polkadot-27a62c70d1eabc57929649d28cb85873057b2157
-    // TODO: check with Sander if we missed something
-    xcm: { fee: { token: "IBTC", amount: "0" }, weightLimit: DEST_WEIGHT },
+    // from chopsticks: fee = 4 - Add 10x margin
+    xcm: { fee: { token: "IBTC", amount: "40" }, weightLimit: DEST_WEIGHT },
   },
   {
     to: "parallel",


### PR DESCRIPTION
Astar is testable now that the chopsticks config changed to a different rpc node. The re-enabled test revealed that astar ibtc fees are set too low, so this pr also increases them.