### PR TITLE
Fix: avoid using acala wrapped api defs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/api-provider.ts
+++ b/src/api-provider.ts
@@ -1,4 +1,3 @@
-import { options } from "@acala-network/api";
 import { combineLatest, map, Observable, race } from "rxjs";
 
 import { ApiPromise, ApiRx, WsProvider } from "@polkadot/api";
@@ -87,10 +86,11 @@ export class ApiProvider {
 
     const wsProvider = new WsProvider(nodes);
 
-    const apiOptions = options({
+    const apiOptions = {
       provider: wsProvider,
       noInitWarn: true,
-    });
+    };
+
     const promiseApi = ApiPromise.create(apiOptions);
 
     return ApiRx.create(apiOptions).pipe(


### PR DESCRIPTION
In order to avoid unexpected validation errors when trying to submit an extrinisic with the `assetId` option.