### PR TITLE
Chore: update kusama asset hub fee estimate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/adapters/statemint.ts
+++ b/src/adapters/statemint.ts
@@ -54,8 +54,8 @@ export const statemineRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {
     to: "kintsugi",
     token: "USDT",
-    // fees from tests on chopsticks: 9_510 atomic units
-    xcm: { fee: { token: "USDT", amount: "15000" }, weightLimit: "Unlimited" },
+    // fees from tests on chopsticks: 8_153 planck, add a minimum of 2x buffer
+    xcm: { fee: { token: "USDT", amount: "20000" }, weightLimit: "Unlimited" },
   },
 ];
 


### PR DESCRIPTION
The previous XCM destination fee estimate  of 0.015 USDT for sending USDT from Kusama AssetHub to Kintsugi was too low.
Increasing the estimate to 0.02 USDT to keep it over 2x of the actual fees observed in chopsticks tests.