### PR TITLE
Test: disable xcm chopsticks tests to/from statemine, parallel heiko

### DIFF
--- a/scripts/kintsugi-chopsticks-test.ts
+++ b/scripts/kintsugi-chopsticks-test.ts
@@ -33,6 +33,8 @@ async function main(): Promise<void> {
     const filterCases: Partial<RouterTestCase>[] = [
         {from: "statemine"},
         {to: "statemine"},
+        {from: "heiko"},
+        {to: "heiko"},
     ];
 
     await runTestCasesAndExit(adaptersEndpoints, filterCases);

--- a/scripts/kintsugi-chopsticks-test.ts
+++ b/scripts/kintsugi-chopsticks-test.ts
@@ -8,7 +8,7 @@ import { HeikoAdapter } from "../src/adapters/parallel";
 import { KusamaAdapter } from "../src/adapters/polkadot";
 import { StatemineAdapter } from "../src/adapters/statemint";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
-import { runTestCasesAndExit } from "./chopsticks-test";
+import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
 
 main().catch((err) => {
     console.log("Error thrown by script:");
@@ -30,5 +30,10 @@ async function main(): Promise<void> {
         kusama:     { adapter: new KusamaAdapter(),     endpoints: ['ws://127.0.0.1:8005'] },
     };
 
-    await runTestCasesAndExit(adaptersEndpoints);
+    const filterCases: Partial<RouterTestCase>[] = [
+        {from: "statemine"},
+        {to: "statemine"},
+    ];
+
+    await runTestCasesAndExit(adaptersEndpoints, filterCases);
 }


### PR DESCRIPTION
Kusama AssetHub (fka. statemine) and parallel heiko block creation is currently broken on chopsticks.