### PR TITLE
Testing: Use acala-network chopsticks in tests

### DIFF
--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
-            --relaychain=scripts/configs/kusama.yml \
+            -r scripts/configs/kusama.yml \
             -p scripts/configs/kintsugi.yml \
             -p scripts/configs/statemine.yml \
             -p scripts/configs/karura.yml \

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -28,9 +28,9 @@ jobs:
           on_retry_command: pkill node; sleep 2
           command: |
             echo "Launching chopsticks..."
-            npx --yes @acala-network/chopsticks@0.3.9 \
+            npx --yes @acala-network/chopsticks@0.9.3 \
               xcm \
-              -r scripts/configs/kusama.yml \
+              --relaychain=scripts/configs/kusama.yml \
               -p scripts/configs/kintsugi.yml \
               -p scripts/configs/statemine.yml \
               -p scripts/configs/karura.yml \

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           name: kintsugi-chopsticks-logs
           path: log.txt
-          retention-days: 14
+          retention-days: 7
 
   chopsticks_interlay_test:
     runs-on: ubuntu-latest
@@ -96,4 +96,4 @@ jobs:
         with:
           name: interlay-chopsticks-logs
           path: log.txt
-          retention-days: 14
+          retention-days: 7

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -21,33 +21,27 @@ jobs:
 
       - name: Run Kintsugi tests
         uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          retry_on: error
-          timeout_minutes: 10
-          on_retry_command: pkill node; sleep 2
-          command: |
-            echo "Launching chopsticks..."
-            npx --yes @acala-network/chopsticks@0.9.3 \
-              xcm \
-              --relaychain=scripts/configs/kusama.yml \
-              -p scripts/configs/kintsugi.yml \
-              -p scripts/configs/statemine.yml \
-              -p scripts/configs/karura.yml \
-              -p scripts/configs/parallel-heiko.yml \
-              -p scripts/configs/bifrost.yml \
-              &> log.txt &
-            echo "Waiting for log to show chopsticks is ready..."
-            tail -f log.txt | grep -q "Connected parachains"
-            echo "Chopsticks launched, start tests."
+        run: |
+          echo "Launching chopsticks..."
+          npx --yes @acala-network/chopsticks@0.9.3 \
+            xcm \
+            --relaychain=scripts/configs/kusama.yml \
+            -p scripts/configs/kintsugi.yml \
+            -p scripts/configs/statemine.yml \
+            -p scripts/configs/karura.yml \
+            -p scripts/configs/parallel-heiko.yml \
+            -p scripts/configs/bifrost.yml \
+            &> log.txt &
+          echo "Waiting for log to show chopsticks is ready..."
+          tail -f log.txt | grep -q "Connected parachains"
+          echo "Chopsticks launched, start tests."
 
-            yarn install --frozen-lockfile
-            npx ts-node scripts/kintsugi-chopsticks-test.ts
-
+          yarn install --frozen-lockfile
+          npx ts-node scripts/kintsugi-chopsticks-test.ts
       - name: Show error log
         if: failure()
         run: |
-          tail -n 100 /app/log.txt
+          tail -n 100 log.txt
       - name: Report status to Discord
         uses: sarisia/actions-status-discord@v1
         if: failure()

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run Kintsugi tests
+      - name: Launch chopsticks
         run: |
-          echo "Launching chopsticks..."
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
             --relaychain=scripts/configs/kusama.yml \
@@ -33,8 +32,9 @@ jobs:
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."
           tail -f log.txt | grep -q "Connected parachains"
-          echo "Chopsticks launched, start tests."
 
+      - name: Run Kintsugi tests
+        run: |
           yarn install --frozen-lockfile
           npx ts-node scripts/kintsugi-chopsticks-test.ts
       - name: Show error log
@@ -51,50 +51,40 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: kintsugi-chopsticks-logs
-          path: /app/log.txt
+          path: log.txt
           retention-days: 14
 
   chopsticks_interlay_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      image: ghcr.io/interlay/chopsticks:master
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run Interlay tests
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 3
-          retry_on: error
-          timeout_minutes: 10
-          on_retry_command: pkill node; sleep 2
-          command: |
-            echo "Launching chopsticks..."
-            cd /app
-            echo "Start..." > log.txt
-            yarn start xcm \
-              --relaychain=configs/polkadot.yml \
-              --parachain=configs/interlay.yml \
-              --parachain=configs/statemint.yml \
-              --parachain=configs/hydradx.yml \
-              --parachain=configs/acala.yml \
-              --parachain=configs/parallel.yml \
-              --parachain=configs/bifrost-polkadot.yml \
-              &> log.txt &
-            echo "Waiting for log to show chopsticks is ready..."
-            tail -f log.txt | grep -q "Connected parachains"
-            echo "Chopsticks launched, start tests."
-            cd -
+      - name: Launch chopsticks
+        run: |
+          npx --yes @acala-network/chopsticks@0.9.3 \
+            xcm \
+            -r scripts/configs/polkadot.yml \
+            -p scripts/configs/interlay.yml \
+            -p scripts/configs/statemint.yml \
+            -p scripts/configs/hydradx.yml \
+            -p scripts/configs/acala.yml \
+            -p scripts/configs/parallel.yml \
+            -p scripts/configs/bifrost-polkadot.yml \
+            &> log.txt &
+          echo "Waiting for log to show chopsticks is ready..."
+          tail -f log.txt | grep -q "Connected parachains"
 
-            yarn install --frozen-lockfile
-            npx ts-node scripts/interlay-chopsticks-test.ts
+      - name: Run Interlay tests
+        run: |
+          yarn install --frozen-lockfile
+          npx ts-node scripts/interlay-chopsticks-test.ts
 
       - name: Show error log
         if: failure()
         run: |
-          tail -n 100 /app/log.txt
+          tail -n 100 log.txt
       - name: Report status to Discord
         uses: sarisia/actions-status-discord@v1
         if: failure()
@@ -105,5 +95,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: interlay-chopsticks-logs
-          path: /app/log.txt
+          path: log.txt
           retention-days: 14

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -15,8 +15,6 @@ jobs:
   chopsticks_kintsugi_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      image: ghcr.io/interlay/chopsticks:master
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,20 +28,17 @@ jobs:
           on_retry_command: pkill node; sleep 2
           command: |
             echo "Launching chopsticks..."
-            cd /app
-            echo "Start..." > log.txt
-            yarn start xcm \
-              --relaychain=configs/kusama.yml \
-              --parachain=configs/kintsugi.yml \
-              --parachain=configs/statemine.yml \
-              --parachain=configs/karura.yml \
-              --parachain=configs/parallel-heiko.yml \
-              --parachain=configs/bifrost.yml \
+            npx @acala-network/chopsticks@0.3.9 xcm \
+              -r scripts/configs/kusama.yml \
+              -p scripts/configs/kintsugi.yml \
+              -p scripts/configs/statemine.yml \
+              -p scripts/configs/karura.yml \
+              -p scripts/configs/parallel-heiko.yml \
+              -p scripts/configs/bifrost.yml \
               &> log.txt &
             echo "Waiting for log to show chopsticks is ready..."
             tail -f log.txt | grep -q "Connected parachains"
             echo "Chopsticks launched, start tests."
-            cd -
 
             yarn install --frozen-lockfile
             npx ts-node scripts/kintsugi-chopsticks-test.ts

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Kintsugi tests
-        uses: nick-fields/retry@v2
         run: |
           echo "Launching chopsticks..."
           npx --yes @acala-network/chopsticks@0.9.3 \

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -32,6 +32,7 @@ jobs:
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."
           tail -f log.txt | grep -q "Connected parachains"
+          echo "... detected chopsticks is ready."
 
       - name: Run Kintsugi tests
         run: |
@@ -75,6 +76,7 @@ jobs:
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."
           tail -f log.txt | grep -q "Connected parachains"
+          echo "... detected chopsticks is ready."
 
       - name: Run Interlay tests
         run: |

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -28,7 +28,8 @@ jobs:
           on_retry_command: pkill node; sleep 2
           command: |
             echo "Launching chopsticks..."
-            npx @acala-network/chopsticks@0.3.9 xcm \
+            npx --yes @acala-network/chopsticks@0.3.9 \
+              xcm \
               -r scripts/configs/kusama.yml \
               -p scripts/configs/kintsugi.yml \
               -p scripts/configs/statemine.yml \

--- a/scripts/configs/acala.yml
+++ b/scripts/configs/acala.yml
@@ -1,0 +1,41 @@
+endpoint:
+  - wss://acala-rpc.aca-api.network
+  - wss://acala-rpc.dwellir.com
+mock-signature-host: true
+block: ${env.ACALA_BLOCK_NUMBER}
+db: ./db.sqlite
+# wasm-override: acala-2150.wasm
+
+import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: AUSD
+        - free: '1000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: DOT
+        - free: '1000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - foreignAsset: 4 # INTR
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - foreignAsset: 3 # IBTC
+        - free: '10000000000'

--- a/scripts/configs/astar.yml
+++ b/scripts/configs/astar.yml
@@ -1,0 +1,24 @@
+endpoint: wss://rpc.astar.network
+mock-signature-host: true
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '1000000000000000000000'
+  Assets:
+    Account:
+      -
+        -
+          - '18446744073709551620' # IBTC
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '10000000000'
+      -
+        -
+          - '18446744073709551621' # INTR
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '500000000000000'

--- a/scripts/configs/bifrost-polkadot.yml
+++ b/scripts/configs/bifrost-polkadot.yml
@@ -1,0 +1,27 @@
+endpoint: wss://hk.p.bifrost-rpc.liebi.com/ws
+# endpoint: wss://bifrost-polkadot.api.onfinality.io/public-ws
+mock-signature-host: true
+
+import-storage:
+  # Sudo:
+  #   Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5Eg2fntQS1bgCgPtXQ9Ysip6RUQkQJEMZqZ9u9qX6fcnhB4H # sibl 2032 (interlay sov)
+          - vtoken2: 0 #VDOT
+        - free: '100000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - vtoken2: 0 # VDOT
+        - free: '100000000000000000'

--- a/scripts/configs/bifrost.yml
+++ b/scripts/configs/bifrost.yml
@@ -1,0 +1,26 @@
+endpoint: wss://bifrost-rpc.dwellir.com
+mock-signature-host: true
+
+import-storage:
+  # Sudo:
+  #   Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5Eg2fnsjADUqvPPTJ17bGgphuxi754R7LsCCqPjt7M5MqVKB # sibl 2092 (kintsugi sov)
+          - vtoken: KSM #VKSM
+        - free: '10000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - vtoken: KSM # VKSM
+        - free: '10000000000000000000'

--- a/scripts/configs/hydradx.yml
+++ b/scripts/configs/hydradx.yml
@@ -1,0 +1,32 @@
+endpoint: wss://hydradx-rpc.dwellir.com
+mock-signature-host: true
+block: ${env.HYDRADX_BLOCK_NUMBER}
+db: ./db.sqlite
+# wasm-override: hydradx_runtime.compact.compressed.wasm
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: 1000000000000000
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - 2 # DAI
+        - free: '100000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - 11 # IBTC
+        - free: '10000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - 17 # INTR
+        - free: '100000000000000000000'

--- a/scripts/configs/interlay.yml
+++ b/scripts/configs/interlay.yml
@@ -1,0 +1,33 @@
+endpoint: wss://api.interlay.io/parachain
+mock-signature-host: true
+
+import-storage:
+  # Sudo:
+  #   Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - token: INTR
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - token: IBTC
+        - free: '10000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - token: DOT
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, usdt
+          - foreignAsset: 2
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, vdot
+          - foreignAsset: 3
+        - free: '100000000000000000'

--- a/scripts/configs/karura.yml
+++ b/scripts/configs/karura.yml
@@ -1,0 +1,42 @@
+endpoint: wss://karura-rpc-0.aca-api.network
+mock-signature-host: true
+block: ${env.KARURA_BLOCK_NUMBER}
+
+import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: KUSD
+        - free: '1000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: KSM
+        - free: '10000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: KINT
+        - free: '10000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: KBTC
+        - free: '10000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - token: LKSM
+        - free: '10000000000000000000'

--- a/scripts/configs/kintsugi.yml
+++ b/scripts/configs/kintsugi.yml
@@ -1,0 +1,38 @@
+endpoint: wss://api-kusama.interlay.io/parachain
+mock-signature-host: true
+
+import-storage:
+  # Sudo:
+  #   Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+  Tokens:
+    Accounts:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - token: KINT
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - token: KBTC
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - token: KSM
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - foreignAsset: 3 # USDT
+        - free: '500000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - ForeignAsset: 2 # LKSM
+        - free: '10000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - ForeignAsset: 5 # VKSM
+        - free: '10000000000000000000'

--- a/scripts/configs/kusama.yml
+++ b/scripts/configs/kusama.yml
@@ -1,0 +1,16 @@
+# endpoint: wss://kusama-rpc.dwellir.com
+endpoint: wss://kusama-rpc.polkadot.io
+mock-signature-host: true
+block: ${env.KUSAMA_BLOCK_NUMBER}
+db: ./db.sqlite
+# wasm-override: kusama_runtime-v9380.compact.compressed.wasm
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '10000000000000000000'

--- a/scripts/configs/parallel-heiko.yml
+++ b/scripts/configs/parallel-heiko.yml
@@ -1,0 +1,24 @@
+endpoint: wss://heiko-rpc.parallel.fi
+mock-signature-host: true
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Assets:
+    Account:
+      -
+        -
+          - 121 # KBTC
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '1000000000000000'
+      -
+        -
+          - 119 # KINT
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '1000000000000000'

--- a/scripts/configs/parallel.yml
+++ b/scripts/configs/parallel.yml
@@ -1,0 +1,24 @@
+endpoint: wss://rpc.parallel.fi
+mock-signature-host: true
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Assets:
+    Account:
+      -
+        -
+          - 122 # IBTC
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '1000000000000000'
+      -
+        -
+          - 120 # INTR
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '1000000000000000'

--- a/scripts/configs/polkadot.yml
+++ b/scripts/configs/polkadot.yml
@@ -1,0 +1,30 @@
+endpoint:
+  - wss://rpc.polkadot.io
+  - wss://polkadot-rpc.dwellir.com
+mock-signature-host: true
+block: ${env.POLKADOT_BLOCK_NUMBER}
+db: ./db.sqlite
+# wasm-override: polkadot_runtime.compact.compressed.wasm
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '10000000000000000000'
+  Council:
+    Members: [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]
+  PhragmenElection:
+    Members:
+      - who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        stake: 1000000000000
+        deposit: 1000000000000
+  TechnicalCommittee:
+    Members: [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]
+  TechnicalMembership:
+    Members: [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]
+  ParasDisputes:
+    $removePrefix: ['disputes'] # those can makes block building super slow

--- a/scripts/configs/statemine.yml
+++ b/scripts/configs/statemine.yml
@@ -1,0 +1,20 @@
+endpoint: wss://statemine-rpc.dwellir.com
+mock-signature-host: true
+block: ${env.STATEMINE_BLOCK_NUMBER}
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: 1000000000000000
+  Assets:
+    Account:
+      -
+        -
+          - 1984 # Alice, usdt
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - balance: 10000000000

--- a/scripts/configs/statemint.yml
+++ b/scripts/configs/statemint.yml
@@ -1,0 +1,19 @@
+endpoint: wss://statemint-rpc.dwellir.com
+mock-signature-host: true
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # # Alice, dot
+        - providers: 1
+          data:
+            free: 1000000000000000
+  Assets:
+    Account:
+      -
+        -
+          - 1984 # Alice, usdt
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - balance: 10000000000


### PR DESCRIPTION
Use upstream chopsticks with local config files (instead of a forked repo with custom docker contrainer) to run chopstick tests.