### PR TITLE
Test: fix polkadot config for chopsticks tests

### DIFF
--- a/scripts/configs/polkadot.yml
+++ b/scripts/configs/polkadot.yml
@@ -15,16 +15,5 @@ import-storage:
         - providers: 1
           data:
             free: '10000000000000000000'
-  Council:
-    Members: [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]
-  PhragmenElection:
-    Members:
-      - who: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-        stake: 1000000000000
-        deposit: 1000000000000
-  TechnicalCommittee:
-    Members: [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]
-  TechnicalMembership:
-    Members: [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]
   ParasDisputes:
     $removePrefix: ['disputes'] # those can makes block building super slow

--- a/src/adapters/statemint.ts
+++ b/src/adapters/statemint.ts
@@ -36,8 +36,8 @@ export const statemintRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {
     to: "interlay",
     token: "USDT",
-    // from recent transfer: 9_510 atomic units, add a minimum of 2x buffer
-    xcm: { fee: { token: "USDT", amount: "20000" }, weightLimit: "Unlimited" },
+    // from recent tests: 11_888 atomic units, use a minimum of 2x buffer
+    xcm: { fee: { token: "USDT", amount: "25000" }, weightLimit: "Unlimited" },
   },
 ];
 


### PR DESCRIPTION
Some pallets started breaking test setup in chopsticks. Removed those from the config.

Additional changes:
- Bumped destination fee estimate for USDT from asset hub to interlay so the estimate is more than 2x the actual test fees.