### PR TITLE
Chore: Switch HydraDX chopsticks test config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# local chopsticks test files
+db.sqlite*
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/scripts/configs/hydradx.yml
+++ b/scripts/configs/hydradx.yml
@@ -1,4 +1,4 @@
-endpoint: wss://hydradx-rpc.dwellir.com
+endpoint: wss://rpc.hydradx.cloud
 mock-signature-host: true
 block: ${env.HYDRADX_BLOCK_NUMBER}
 db: ./db.sqlite


### PR DESCRIPTION
… to use their own wss endpoint rather than dwellir's.

Hopefully their endpoint reduces the test flakiness we've been observing.