### PR TITLE
Test: Reenable HydraDX chopsticks tests

### DIFF
--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -69,6 +69,7 @@ jobs:
             -r scripts/configs/polkadot.yml \
             -p scripts/configs/interlay.yml \
             -p scripts/configs/statemint.yml \
+            -p scripts/configs/hydradx.yml \
             -p scripts/configs/acala.yml \
             -p scripts/configs/parallel.yml \
             -p scripts/configs/bifrost-polkadot.yml \

--- a/scripts/configs/kusama.yml
+++ b/scripts/configs/kusama.yml
@@ -1,5 +1,6 @@
-# endpoint: wss://kusama-rpc.dwellir.com
-endpoint: wss://kusama-rpc.polkadot.io
+endpoint:
+  - wss://kusama-rpc.dwellir.com
+  - wss://kusama-rpc.dwellir.com
 mock-signature-host: true
 block: ${env.KUSAMA_BLOCK_NUMBER}
 db: ./db.sqlite

--- a/scripts/configs/polkadot.yml
+++ b/scripts/configs/polkadot.yml
@@ -1,6 +1,6 @@
 endpoint:
-  - wss://rpc.polkadot.io
   - wss://polkadot-rpc.dwellir.com
+  - wss://rpc.polkadot.io
 mock-signature-host: true
 block: ${env.POLKADOT_BLOCK_NUMBER}
 db: ./db.sqlite

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -25,21 +25,18 @@ async function main(): Promise<void> {
         //           relaychain gets its port last after all parachains.
         interlay: { adapter: new InterlayAdapter(), endpoints: ['ws://127.0.0.1:8000'] },
         statemint: { adapter: new StatemintAdapter(), endpoints: ['ws://127.0.0.1:8001'] },
-        // disable hydra - rpc too flaky to use in regular test runs
-        // hydra: { adapter: new HydraAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
-        acala: { adapter: new AcalaAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
+        hydra: { adapter: new HydraAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
+        acala: { adapter: new AcalaAdapter(), endpoints: ['ws://127.0.0.1:8003'] },
         // disable astar - rpc currently is too fragile for use in recurring tests
         // astar:      { adapter: new AstarAdapter(),      endpoints: ['ws://127.0.0.1:8004'] },
-        parallel: { adapter: new ParallelAdapter(), endpoints: ['ws://127.0.0.1:8003'] },
-        bifrost_polkadot: { adapter: new BifrostPolkadotAdapter(), endpoints: ['ws://127.0.0.1:8004']},
-        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8005'] },
+        parallel: { adapter: new ParallelAdapter(), endpoints: ['ws://127.0.0.1:8004'] },
+        bifrost_polkadot: { adapter: new BifrostPolkadotAdapter(), endpoints: ['ws://127.0.0.1:8005']},
+        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8006'] },
     };
 
     const filterCases: Partial<RouterTestCase>[] = [
         {from: "astar"},
         {to: "astar"},
-        {from: "hydra"},
-        {to: "hydra"},
     ];
 
     await runTestCasesAndExit(adaptersEndpoints, filterCases);

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -4,6 +4,7 @@
 import { PolkadotAdapter } from "../src/adapters/polkadot";
 import { InterlayAdapter } from "../src/adapters/interlay";
 import { StatemintAdapter } from "../src/adapters/statemint";
+import { HydraAdapter } from "../src/adapters/hydradx";
 import { AcalaAdapter } from "../src/adapters/acala";
 import { ParallelAdapter } from "../src/adapters/parallel";
 import { BifrostPolkadotAdapter } from "../src/adapters/bifrost";


### PR DESCRIPTION
Resolves #138

Changes:
- Reenable HydraDX chopsticks tests
- Modify ED check for HydraDX only to bump minimal amount's fees by 10%

The second part is to avoid issues where fees required change due to previous test transactions since HydraDX uses the token/HDX pair for fees which can slip and lead to false negatives.

This bump by an arbitrary percentage (10%) isn't perfect, but would at least catch some cases where the ED changes by a value that's in excess of actual fees plus 10%.
Given our fee estimate is 10x and tests start failing when the estimate is less than 2x the actual fee, the minimum amount returned by the XCM bridge should still be large enough to cover small changes in ED not caught.