### PR TITLE
Test: Make chopsticks tests more resilient

### DIFF
--- a/.github/workflows/xcm-assethub-tests.yml
+++ b/.github/workflows/xcm-assethub-tests.yml
@@ -1,8 +1,8 @@
 ---
-name: XCM tests
+name: AssetHub XCM tests
 on:
   schedule:
-    - cron: '12 */2 * * *' # Run every 2 hours
+    - cron: '38 */2 * * *' # Run every 2 hours
   push:
     branches:
       - master
@@ -11,9 +11,9 @@ on:
       - master
 
 jobs:
-  chopsticks_kintsugi_test:
+  chopsticks_kusama_assethub_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,18 +25,16 @@ jobs:
             xcm \
             -r scripts/configs/kusama.yml \
             -p scripts/configs/kintsugi.yml \
-            -p scripts/configs/karura.yml \
-            -p scripts/configs/parallel-heiko.yml \
-            -p scripts/configs/bifrost.yml \
+            -p scripts/configs/statemine.yml \
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."
           tail -f log.txt | grep -q "Connected parachains"
           echo "... detected chopsticks is ready."
 
-      - name: Run Kintsugi tests
+      - name: Run Kusama AssetHub tests
         run: |
           yarn install --frozen-lockfile
-          npx ts-node scripts/kintsugi-chopsticks-test.ts
+          npx ts-node scripts/kusama-chopsticks-assethub-test.ts
       - name: Show error log
         if: failure()
         run: |
@@ -46,17 +44,10 @@ jobs:
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-      - name: Upload logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: kintsugi-chopsticks-logs
-          path: log.txt
-          retention-days: 7
 
-  chopsticks_interlay_test:
+  chopsticks_polkadot_assethub_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,21 +59,16 @@ jobs:
             xcm \
             -r scripts/configs/polkadot.yml \
             -p scripts/configs/interlay.yml \
-            -p scripts/configs/hydradx.yml \
-            -p scripts/configs/acala.yml \
-            -p scripts/configs/astar.yml \
-            -p scripts/configs/parallel.yml \
-            -p scripts/configs/bifrost-polkadot.yml \
+            -p scripts/configs/statemint.yml \
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."
           tail -f log.txt | grep -q "Connected parachains"
           echo "... detected chopsticks is ready."
 
-      - name: Run Interlay tests
+      - name: Run Polkadot AssetHub tests
         run: |
           yarn install --frozen-lockfile
-          npx ts-node scripts/interlay-chopsticks-test.ts
-
+          npx ts-node scripts/polkadot-chopsticks-assethub-test.ts
       - name: Show error log
         if: failure()
         run: |
@@ -92,10 +78,3 @@ jobs:
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-      - name: Upload logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interlay-chopsticks-logs
-          path: log.txt
-          retention-days: 7

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
-        timeout-minutes: 3
+        timeout-minutes: 5
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
-        timeout-minutes: 3
+        timeout-minutes: 5
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -2,7 +2,7 @@
 name: Daily XCM tests
 on:
   schedule:
-    - cron: '5 * * * *' # Run hourly
+    - cron: '12 */2 * * *' # Run every 2 hours
   push:
     branches:
       - master
@@ -13,7 +13,7 @@ on:
 jobs:
   chopsticks_kintsugi_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
 
   chopsticks_kusama_assethub_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
 
   chopsticks_interlay_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -133,7 +133,7 @@ jobs:
 
   chopsticks_polkadot_assethub_test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
-        timeout-minutes: 5
+        timeout-minutes: 3
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
-        timeout-minutes: 5
+        timeout-minutes: 3
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -71,7 +71,6 @@ jobs:
             -p scripts/configs/hydradx.yml \
             -p scripts/configs/acala.yml \
             -p scripts/configs/astar.yml \
-            -p scripts/configs/parallel.yml \
             -p scripts/configs/bifrost-polkadot.yml \
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - master
 
-
 jobs:
   chopsticks_kintsugi_test:
     runs-on: ubuntu-latest
@@ -25,7 +24,6 @@ jobs:
             xcm \
             -r scripts/configs/kusama.yml \
             -p scripts/configs/kintsugi.yml \
-            -p scripts/configs/statemine.yml \
             -p scripts/configs/karura.yml \
             -p scripts/configs/parallel-heiko.yml \
             -p scripts/configs/bifrost.yml \
@@ -55,6 +53,39 @@ jobs:
           path: log.txt
           retention-days: 7
 
+  chopsticks_kusama_assethub_test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Launch chopsticks
+        run: |
+          npx --yes @acala-network/chopsticks@0.9.3 \
+            xcm \
+            -r scripts/configs/kusama.yml \
+            -p scripts/configs/kintsugi.yml \
+            -p scripts/configs/statemine.yml \
+            &> log.txt &
+          echo "Waiting for log to show chopsticks is ready..."
+          tail -f log.txt | grep -q "Connected parachains"
+          echo "... detected chopsticks is ready."
+
+      - name: Run Kusama AssetHub tests
+        run: |
+          yarn install --frozen-lockfile
+          npx ts-node scripts/kusama-chopsticks-assethub-test.ts
+      - name: Show error log
+        if: failure()
+        run: |
+          tail -n 100 log.txt
+      # - name: Report status to Discord
+      #   uses: sarisia/actions-status-discord@v1
+      #   if: failure()
+      #   with:
+      #     webhook: ${{ secrets.DISCORD_WEBHOOK }}
+
   chopsticks_interlay_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -68,7 +99,6 @@ jobs:
             xcm \
             -r scripts/configs/polkadot.yml \
             -p scripts/configs/interlay.yml \
-            -p scripts/configs/statemint.yml \
             -p scripts/configs/hydradx.yml \
             -p scripts/configs/acala.yml \
             -p scripts/configs/astar.yml \
@@ -100,3 +130,36 @@ jobs:
           name: interlay-chopsticks-logs
           path: log.txt
           retention-days: 7
+
+  chopsticks_polkadot_assethub_test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Launch chopsticks
+        run: |
+          npx --yes @acala-network/chopsticks@0.9.3 \
+            xcm \
+            -r scripts/configs/polkadot.yml \
+            -p scripts/configs/interlay.yml \
+            -p scripts/configs/statemint.yml \
+            &> log.txt &
+          echo "Waiting for log to show chopsticks is ready..."
+          tail -f log.txt | grep -q "Connected parachains"
+          echo "... detected chopsticks is ready."
+
+      - name: Run Polkadot AssetHub tests
+        run: |
+          yarn install --frozen-lockfile
+          npx ts-node scripts/polkadot-chopsticks-assethub-test.ts
+      - name: Show error log
+        if: failure()
+        run: |
+          tail -n 100 log.txt
+      # - name: Report status to Discord
+      #   uses: sarisia/actions-status-discord@v1
+      #   if: failure()
+      #   with:
+      #     webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
+        timeout-minutes: 3
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
@@ -61,6 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
+        timeout-minutes: 3
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
@@ -94,6 +96,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
+        timeout-minutes: 3
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \
@@ -139,6 +142,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Launch chopsticks
+        timeout-minutes: 3
         run: |
           npx --yes @acala-network/chopsticks@0.9.3 \
             xcm \

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "test:ci": "jest --forceExit",
     "lint": "polkadot-dev-run-lint",
     "chopsticks-test:kintsugi": "ts-node scripts/kintsugi-chopsticks-test",
-    "chopsticks-test:interlay": "ts-node scripts/interlay-chopsticks-test"
+    "chopsticks-test:interlay": "ts-node scripts/interlay-chopsticks-test",
+    "chopsticks-test:kusama-assethub": "ts-node scripts/kusama-chopsticks-assethub-test",
+    "chopsticks-test:polkadot-assethub": "ts-node scripts/polkadot-chopsticks-assethub-test"
   },
   "peerDependencies": {
     "@polkadot/api": "^10"

--- a/scripts/chopsticks-test.ts
+++ b/scripts/chopsticks-test.ts
@@ -191,11 +191,13 @@ async function retryCheckTransfer(
  * Can skip specific test cases provided by the skipCases filter, and will also skip routes if no matching adapter has been provided.
  * 
  * @param adapterEndpoints Records containing ChainName as key, an instantiated adapter and a list of ws(s) links as endpoints for each.
+ * @param includeAssetHubSepcialCases Boolean value whether to add realy chaing to/from assethub test cases (true) or not (false).
  * @param skipCases An array of xcm test cases to skip.
  */
 export async function runTestCasesAndExit(
     // record key is chainname
     adapterEndpoints: Record<ChainName, { adapter: BaseCrossChainAdapter, endpoints: Array<string> }>,
+    includeAssetHubSepcialCases: boolean = false,
     // skip cases: array of to, from and/or token to skip tests for
     skipCases: Partial<RouterTestCase>[] = []
 ): Promise<void> {
@@ -231,21 +233,23 @@ export async function runTestCasesAndExit(
     }));
 
     // add in special cases: polkadot/kusama <=> asset hub
-    const relayId = chains.includes("polkadot") ? "polkadot" : "kusama";
-    const assetHubId = relayId === "polkadot" ? "statemint" : "statemine";
-    const token = relayId === "polkadot" ? "DOT" : "KSM";
-    testCases.push(
-        {
-            to: assetHubId as ChainName,
-            from: relayId as ChainName,
-            token
-        },
-        {
-            to: relayId as ChainName,
-            from: assetHubId as ChainName,
-            token
-        },
-    );
+    if (includeAssetHubSepcialCases) {
+        const relayId = chains.includes("polkadot") ? "polkadot" : "kusama";
+        const assetHubId = relayId === "polkadot" ? "statemint" : "statemine";
+        const token = relayId === "polkadot" ? "DOT" : "KSM";
+        testCases.push(
+            {
+                to: assetHubId as ChainName,
+                from: relayId as ChainName,
+                token
+            },
+            {
+                to: relayId as ChainName,
+                from: assetHubId as ChainName,
+                token
+            },
+        );
+    }
 
     const isSkipCase = (testCase: {to: ChainName, from: ChainName, token: string}): boolean => {
         return skipCases.some((skipCase) =>

--- a/scripts/chopsticks-test.ts
+++ b/scripts/chopsticks-test.ts
@@ -191,13 +191,13 @@ async function retryCheckTransfer(
  * Can skip specific test cases provided by the skipCases filter, and will also skip routes if no matching adapter has been provided.
  * 
  * @param adapterEndpoints Records containing ChainName as key, an instantiated adapter and a list of ws(s) links as endpoints for each.
- * @param includeAssetHubSepcialCases Boolean value whether to add realy chaing to/from assethub test cases (true) or not (false).
+ * @param includeAssetHubSpecialCases Boolean value whether to add relay chain to/from assethub test cases (true) or not (false).
  * @param skipCases An array of xcm test cases to skip.
  */
 export async function runTestCasesAndExit(
     // record key is chainname
     adapterEndpoints: Record<ChainName, { adapter: BaseCrossChainAdapter, endpoints: Array<string> }>,
-    includeAssetHubSepcialCases: boolean = false,
+    includeAssetHubSpecialCases: boolean = false,
     // skip cases: array of to, from and/or token to skip tests for
     skipCases: Partial<RouterTestCase>[] = []
 ): Promise<void> {
@@ -233,7 +233,7 @@ export async function runTestCasesAndExit(
     }));
 
     // add in special cases: polkadot/kusama <=> asset hub
-    if (includeAssetHubSepcialCases) {
+    if (includeAssetHubSpecialCases) {
         const relayId = chains.includes("polkadot") ? "polkadot" : "kusama";
         const assetHubId = relayId === "polkadot" ? "statemint" : "statemine";
         const token = relayId === "polkadot" ? "DOT" : "KSM";

--- a/scripts/configs/parallel.yml
+++ b/scripts/configs/parallel.yml
@@ -1,6 +1,6 @@
 endpoint:
-  - wss://polkadot-rpc.parallel.fi
   - wss://parallel-rpc.dwellir.com
+  - wss://polkadot-rpc.parallel.fi
 mock-signature-host: true
 
 import-storage:

--- a/scripts/configs/parallel.yml
+++ b/scripts/configs/parallel.yml
@@ -1,6 +1,6 @@
 endpoint:
-  - wss://parallel-rpc.dwellir.com
   - wss://polkadot-rpc.parallel.fi
+  - wss://parallel-rpc.dwellir.com
 mock-signature-host: true
 
 import-storage:

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -9,7 +9,7 @@ import { AstarAdapter } from "../src/adapters/astar";
 import { ParallelAdapter } from "../src/adapters/parallel";
 import { BifrostPolkadotAdapter } from "../src/adapters/bifrost";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
-import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
+import { runTestCasesAndExit } from "./chopsticks-test";
 
 main().catch((err) => {
     console.log("Error thrown by script:");

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -6,7 +6,7 @@ import { InterlayAdapter } from "../src/adapters/interlay";
 import { HydraAdapter } from "../src/adapters/hydradx";
 import { AcalaAdapter } from "../src/adapters/acala";
 import { AstarAdapter } from "../src/adapters/astar";
-import { ParallelAdapter } from "../src/adapters/parallel";
+// import { ParallelAdapter } from "../src/adapters/parallel";
 import { BifrostPolkadotAdapter } from "../src/adapters/bifrost";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
 import { runTestCasesAndExit } from "./chopsticks-test";
@@ -27,9 +27,9 @@ async function main(): Promise<void> {
         hydra: { adapter: new HydraAdapter(), endpoints: ['ws://127.0.0.1:8001'] },
         acala: { adapter: new AcalaAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
         astar: { adapter: new AstarAdapter(), endpoints: ['ws://127.0.0.1:8003'] },
-        parallel: { adapter: new ParallelAdapter(), endpoints: ['ws://127.0.0.1:8004'] },
-        bifrost_polkadot: { adapter: new BifrostPolkadotAdapter(), endpoints: ['ws://127.0.0.1:8005']},
-        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8006'] },
+        // parallel: { adapter: new ParallelAdapter(), endpoints: ['ws://127.0.0.1:8004'] },
+        bifrost_polkadot: { adapter: new BifrostPolkadotAdapter(), endpoints: ['ws://127.0.0.1:8004']},
+        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8005'] },
     };
 
     await runTestCasesAndExit(adaptersEndpoints);

--- a/scripts/kusama-chopsticks-assethub-test.ts
+++ b/scripts/kusama-chopsticks-assethub-test.ts
@@ -1,13 +1,11 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* tslint:disable:no-unused-variable */
-import { KaruraAdapter } from "../src/adapters/acala";
-import { BifrostKusamaAdapter } from "../src/adapters/bifrost";
 import { KintsugiAdapter } from "../src/adapters/interlay";
-import { HeikoAdapter } from "../src/adapters/parallel";
+import { StatemineAdapter } from "../src/adapters/statemint";
 import { KusamaAdapter } from "../src/adapters/polkadot";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
-import { runTestCasesAndExit } from "./chopsticks-test";
+import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
 
 main().catch((err) => {
     console.log("Error thrown by script:");
@@ -22,11 +20,21 @@ async function main(): Promise<void> {
         // reminder: parachains get ports in oder of arguments, starting with 8000 and incremented for each following one; 
         //           relaychain gets its port last after all parachains.
         kintsugi:   { adapter: new KintsugiAdapter(),   endpoints: ['ws://127.0.0.1:8000'] },
-        karura:     { adapter: new KaruraAdapter(),     endpoints: ['ws://127.0.0.1:8001'] },
-        heiko:      { adapter: new HeikoAdapter(),      endpoints: ['ws://127.0.0.1:8002'] },
-        bifrost:    { adapter: new BifrostKusamaAdapter(),    endpoints: ['ws://127.0.0.1:8003'] },
-        kusama:     { adapter: new KusamaAdapter(),     endpoints: ['ws://127.0.0.1:8004'] },
+        statemine: { adapter: new StatemineAdapter(), endpoints: ['ws://127.0.0.1:8001'] },
+        kusama:     { adapter: new KusamaAdapter(),     endpoints: ['ws://127.0.0.1:8002'] },
     };
 
-    await runTestCasesAndExit(adaptersEndpoints);
+    // already tested in kintsugi-chopsticks-test
+    const skipCases: Partial<RouterTestCase>[] = [
+        {
+            from: "kintsugi",
+            to: "kusama",
+        },
+        {
+            from: "kusama",
+            to: "kintsugi",
+        },
+    ];
+
+    await runTestCasesAndExit(adaptersEndpoints, true, skipCases);
 }

--- a/scripts/polkadot-chopsticks-assethub-test.ts
+++ b/scripts/polkadot-chopsticks-assethub-test.ts
@@ -3,11 +3,7 @@
 /* tslint:disable:no-unused-variable */
 import { PolkadotAdapter } from "../src/adapters/polkadot";
 import { InterlayAdapter } from "../src/adapters/interlay";
-import { HydraAdapter } from "../src/adapters/hydradx";
-import { AcalaAdapter } from "../src/adapters/acala";
-import { AstarAdapter } from "../src/adapters/astar";
-import { ParallelAdapter } from "../src/adapters/parallel";
-import { BifrostPolkadotAdapter } from "../src/adapters/bifrost";
+import { StatemintAdapter } from "../src/adapters/statemint";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
 import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
 
@@ -24,13 +20,21 @@ async function main(): Promise<void> {
         // reminder: parachains get ports in oder of arguments, starting with 8000 and incremented for each following one; 
         //           relaychain gets its port last after all parachains.
         interlay: { adapter: new InterlayAdapter(), endpoints: ['ws://127.0.0.1:8000'] },
-        hydra: { adapter: new HydraAdapter(), endpoints: ['ws://127.0.0.1:8001'] },
-        acala: { adapter: new AcalaAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
-        astar: { adapter: new AstarAdapter(), endpoints: ['ws://127.0.0.1:8003'] },
-        parallel: { adapter: new ParallelAdapter(), endpoints: ['ws://127.0.0.1:8004'] },
-        bifrost_polkadot: { adapter: new BifrostPolkadotAdapter(), endpoints: ['ws://127.0.0.1:8005']},
-        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8006'] },
+        statemint: { adapter: new StatemintAdapter(), endpoints: ['ws://127.0.0.1:8001'] },
+        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
     };
 
-    await runTestCasesAndExit(adaptersEndpoints);
+    // already tested in interlay-chopsticks-test
+    const skipCases: Partial<RouterTestCase>[] = [
+        {
+            from: "interlay",
+            to: "polkadot",
+        },
+        {
+            from: "polkadot",
+            to: "interlay",
+        },
+    ];
+
+    await runTestCasesAndExit(adaptersEndpoints, true, skipCases);
 }


### PR DESCRIPTION
Several fixes to try and make XCM chopsticks tests more stable and avoid some critical errors (particularly for AssetHub adapters) from hiding other issues.

Changes: 
- Separate tests involving AssetHub from other XCM tests
And run those on a slightly different schedule as the pre-existing XCM tests to avoid rate limiting due to opening too many channels at once.

- Reduce frequency of automated tests to every 2 hours (was: every hour)
This may alleviate some cases of rate limiting. In any event, given the significant amount of failures due to flakiness, we need to check in quite frequently anyway. So we do not gain much by running these tests every hour as opposed to every other hour.

- Disable ParallelFi adapter for chopsticks tests
Something seems to have changed on their end while I was working on this fix. Chopsticks now refuses to launch for Parallel. Needs more work to investigate and fix Parallel in another PR.