### PR TITLE
Fix: Destination weights and fee estimates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/adapters/hydradx.ts
+++ b/src/adapters/hydradx.ts
@@ -18,7 +18,7 @@ import {
 } from "../types";
 import { xTokensHelper } from "../utils/xtokens-helper";
 
-const DEST_WEIGHT = "5000000000";
+const DEST_WEIGHT = "Unlimited";
 
 export const hydraRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -149,7 +149,8 @@ export const kintsugiRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "statemine",
     token: "USDT",
     xcm: {
-      fee: { token: "USDT", amount: "10000" },
+      // fees in tests: 7_186, need a minimum of 2x as safe buffer
+      fee: { token: "USDT", amount: "20000" },
       weightLimit: DEST_WEIGHT,
     },
   },


### PR DESCRIPTION
- Set destination weight to unlimited for hydradx to interlay transfers
- Increase destination fee estimate for USDT from kintsugi to asset hub