### PR TITLE
Chore: increase assethub dest fee estimate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/adapters/polkadot.ts
+++ b/src/adapters/polkadot.ts
@@ -30,8 +30,8 @@ export const polkadotRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "statemint",
     token: "DOT",
     xcm: {
-      // recent transfer: 1_433_579 - add 10x buffer
-      fee: { token: "DOT", amount: "14335790" },
+      // recent transfer: 35_930_000 - use 10x as buffer
+      fee: { token: "DOT", amount: "359300000" },
       weightLimit: "Unlimited",
     },
   },


### PR DESCRIPTION
Destination fees for DOT transfers to AssetHub have increased dramatically. Increase the fee estimate accordingly to have a safety buffer that is greater than the actual fees observed.