### PR TITLE
Feat: Add USDC and initial routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/scripts/configs/hydradx.yml
+++ b/scripts/configs/hydradx.yml
@@ -34,3 +34,8 @@ import-storage:
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
           - 17 # INTR
         - free: '100000000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+          - 22 # USDC
+        - free: '1000000000'

--- a/scripts/configs/interlay.yml
+++ b/scripts/configs/interlay.yml
@@ -34,3 +34,8 @@ import-storage:
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, vdot
           - foreignAsset: 3
         - free: '100000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, usdc
+          - foreignAsset: 12
+        - free: '1000000000'

--- a/scripts/configs/statemint.yml
+++ b/scripts/configs/statemint.yml
@@ -18,6 +18,11 @@ import-storage:
     Account:
       -
         -
+          - 1337 # Alice, USDC
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - balance: 10000000000
+      -
+        -
           - 1984 # Alice, usdt
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
         - balance: 10000000000

--- a/scripts/configs/statemint.yml
+++ b/scripts/configs/statemint.yml
@@ -26,3 +26,13 @@ import-storage:
           - 1984 # Alice, usdt
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
         - balance: 10000000000
+      -
+        -
+          - 1337 # Sibling:2032 (Interlay), USDC
+          - 13cKp89UHns9eDQQV3CZ1seFH6QQ6bnVeLHe4SpsekeJse1r
+        - balance: 100000000000
+      -
+        -
+          - 1984 # Sibling:2032 (Interlay), usdt
+          - 13cKp89UHns9eDQQV3CZ1seFH6QQ6bnVeLHe4SpsekeJse1r
+        - balance: 100000000000

--- a/src/adapters/hydradx.ts
+++ b/src/adapters/hydradx.ts
@@ -39,15 +39,15 @@ export const hydraRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
       weightLimit: DEST_WEIGHT,
     },
   },
-  {
-    to: "interlay",
-    token: "USDC",
-    // currently unknown until registered, assume similar to USDT for now
-    xcm: {
-      fee: { token: "USDC", amount: "25000" },
-      weightLimit: DEST_WEIGHT,
-    },
-  },
+  // {
+  //   to: "interlay",
+  //   token: "USDC",
+  //   // currently unknown until registered, assume similar to USDT for now
+  //   xcm: {
+  //     fee: { token: "USDC", amount: "25000" },
+  //     weightLimit: DEST_WEIGHT,
+  //   },
+  // },
 ];
 
 export const hydraTokensConfig: Record<string, ExtendedToken> = {
@@ -72,13 +72,13 @@ export const hydraTokensConfig: Record<string, ExtendedToken> = {
     ed: "6164274209",
     toRaw: () => 17,
   },
-  USDC: {
-    name: "USDC",
-    symbol: "USDC",
-    decimals: 6,
-    ed: "10000",
-    toRaw: () => 22,
-  },
+  // USDC: {
+  //   name: "USDC",
+  //   symbol: "USDC",
+  //   decimals: 6,
+  //   ed: "10000",
+  //   toRaw: () => 22,
+  // },
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/src/adapters/hydradx.ts
+++ b/src/adapters/hydradx.ts
@@ -39,6 +39,15 @@ export const hydraRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
       weightLimit: DEST_WEIGHT,
     },
   },
+  {
+    to: "interlay",
+    token: "USDC",
+    // currently unknown until registered, assume similar to USDT for now
+    xcm: {
+      fee: { token: "USDC", amount: "25000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
 ];
 
 export const hydraTokensConfig: Record<string, ExtendedToken> = {
@@ -62,6 +71,13 @@ export const hydraTokensConfig: Record<string, ExtendedToken> = {
     decimals: 10,
     ed: "6164274209",
     toRaw: () => 17,
+  },
+  USDC: {
+    name: "USDC",
+    symbol: "USDC",
+    decimals: 6,
+    ed: "10000",
+    toRaw: () => 22,
   },
 };
 

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -106,15 +106,15 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
       weightLimit: DEST_WEIGHT,
     },
   },
-  {
-    to: "hydra",
-    token: "USDC",
-    xcm: {
-      // seen on subscan: 2_732 atomic units, need a minimum of 2x as buffer
-      fee: { token: "USDC", amount: "10000" },
-      weightLimit: DEST_WEIGHT,
-    },
-  },
+  // {
+  //   to: "hydra",
+  //   token: "USDC",
+  //   xcm: {
+  //     // seen on subscan: 2_732 atomic units, need a minimum of 2x as buffer
+  //     fee: { token: "USDC", amount: "10000" },
+  //     weightLimit: DEST_WEIGHT,
+  //   },
+  // },
   {
     to: "bifrost_polkadot",
     token: "VDOT",

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -75,6 +75,15 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   },
   {
     to: "statemint",
+    token: "USDC",
+    xcm: {
+      // seen on subscan: 70_000 atomic units, need a minimum of 2x as buffer
+      fee: { token: "USDC", amount: "150000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "statemint",
     token: "USDT",
     xcm: {
       // fees from tests with chopsticks: 700_000 atomic units, need a minimum of 2x as buffer
@@ -94,6 +103,15 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     // in chopsticks tests: 1_577_910_765 - add 10x safety margin
     xcm: {
       fee: { token: "INTR", amount: "15779107650" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "hydra",
+    token: "USDC",
+    xcm: {
+      // seen on subscan: 2_732 atomic units, need a minimum of 2x as buffer
+      fee: { token: "USDC", amount: "10000" },
       weightLimit: DEST_WEIGHT,
     },
   },
@@ -191,6 +209,7 @@ export const interlayTokensConfig: Record<
     DOT: { name: "DOT", symbol: "DOT", decimals: 10, ed: "0" },
     IBTC: { name: "IBTC", symbol: "IBTC", decimals: 8, ed: "0" },
     INTR: { name: "INTR", symbol: "INTR", decimals: 10, ed: "0" },
+    USDC: { name: "USDC", symbol: "USDC", decimals: 6, ed: "0" },
     USDT: { name: "USDT", symbol: "USDT", decimals: 6, ed: "0" },
     VDOT: { name: "VDOT", symbol: "VDOT", decimals: 10, ed: "0" },
   },
@@ -219,6 +238,7 @@ const INTERLAY_SUPPORTED_TOKENS: Record<string, unknown> = {
   INTR: { Token: "INTR" },
   USDT: { ForeignAsset: 2 },
   VDOT: { ForeignAsset: 3 },
+  USDC: { ForeignAsset: 12 },
 };
 
 const getSupportedTokens = (chainname: string): Record<string, unknown> => {

--- a/src/adapters/statemint.ts
+++ b/src/adapters/statemint.ts
@@ -39,6 +39,12 @@ export const statemintRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     // from recent tests: 11_888 atomic units, use a minimum of 2x buffer
     xcm: { fee: { token: "USDT", amount: "25000" }, weightLimit: "Unlimited" },
   },
+  {
+    to: "interlay",
+    token: "USDC",
+    // currently unknown until registered, assume similar to USDT for now
+    xcm: { fee: { token: "USDC", amount: "25000" }, weightLimit: "Unlimited" },
+  },
 ];
 
 export const statemineRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
@@ -70,14 +76,17 @@ export const statemineTokensConfig: Record<
   },
   statemint: {
     DOT: { name: "DOT", symbol: "DOT", decimals: 10, ed: "1000000000" },
+    // ED set according to minBalance value of assets.asset(1337)
+    USDC: { name: "USDC", symbol: "USDC", decimals: 6, ed: "70000" },
     // ED set according to minBalance value of assets.asset(1984)
-    USDT: { name: "USDT", symbol: "USDT", decimals: 6, ed: "700000" },
+    USDT: { name: "USDT", symbol: "USDT", decimals: 6, ed: "70000" },
   },
 };
 
 const SUPPORTED_TOKENS: Record<string, BN> = {
   RMRK: new BN(8),
   ARIS: new BN(16),
+  USDC: new BN(1337),
   USDT: new BN(1984),
 };
 


### PR DESCRIPTION
Resolves #165 

Add USDC as foreign asset and add route:
- Interlay <-> AssetHub

~~_Note_: PR #174 enables one additional USDC routes and is preferable over this PR, but only if chopsticks tests pass.~~