### PR TITLE
Fix: Increase Polkadot extrinsic fee estimate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/adapters/polkadot.ts
+++ b/src/adapters/polkadot.ts
@@ -155,10 +155,11 @@ class BasePolkadotAdapter extends BaseCrossChainAdapter {
     }).pipe(
       map(({ balance }) => {
         const tokenMeta = this.balanceAdapter?.getToken(token);
-        // fixed fee of 0.05 ksm or DOT until we get paymentinfo to work again
+        // fixed fee of 0.1 of KSM or DOT until we get paymentinfo to work again
+        // 0.06 was observed needed for DOT (tested in chopsticks), KSM needs less than that
         const fee = FN.fromInner(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          0.05 * Math.pow(10, tokenMeta!.decimals),
+          0.1 * Math.pow(10, tokenMeta!.decimals),
           tokenMeta?.decimals
         );
 


### PR DESCRIPTION
Resolves interlay/interbtc-ui#1644

Our previous hard-coded Polkadot extrinsic submission fee (for XCM transfers) turns out to be too low.
This PR bumps the estimate so transferring the max amount as indicated by the XCM lib prevents the Polkadot account being reaped.

0.06 DOT was just enough in local tests with chopsticks, but to be on the safe side, we're rounding that up to 0.1 DOT.