### PR TITLE
Feat: Add routes for BNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All channels support transfers in both directions.
 | ------------------ | --------- |
 | acala              | INTR IBTC |
 | astar              | INTR IBTC |
-| bifrost            | VDOT      |
+| bifrost            | BNC VDOT  |
 | parallel           | INTR IBTC |
 | polkadot           | DOT       |
 | polkadot asset hub | USDT      |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/scripts/configs/bifrost-polkadot.yml
+++ b/scripts/configs/bifrost-polkadot.yml
@@ -11,7 +11,13 @@ import-storage:
     Account:
       -
         -
-          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '1000000000000000'
+      -
+        -
+          - 5Eg2fntQS1bgCgPtXQ9Ysip6RUQkQJEMZqZ9u9qX6fcnhB4H # sibl 2032 (interlay sov)
         - providers: 1
           data:
             free: '1000000000000000'

--- a/scripts/configs/interlay.yml
+++ b/scripts/configs/interlay.yml
@@ -36,6 +36,11 @@ import-storage:
         - free: '100000000000000000'
       -
         -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, bnc
+          - foreignAsset: 11
+        - free: '1000000000000000000'
+      -
+        -
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, usdc
           - foreignAsset: 12
         - free: '1000000000'

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -51,7 +51,7 @@ export const bifrostPolkadotRoutersConfig: Omit<
     to: "interlay",
     token: "BNC",
     xcm: {
-      // TODO: test in chopsticks
+      // chopsticks test value: 48_800_000_000, add buffer
       fee: { token: "BNC", amount: "50000000000" },
       weightLimit: DEST_WEIGHT,
     },

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -116,14 +116,15 @@ class BifrostBalanceAdapter extends BalanceAdapter {
   ): Observable<BalanceData> {
     const storage = this.storages.balances(address);
 
+    console.log("inside subscribe balance");
     if (token === this.nativeToken) {
       return storage.observable.pipe(
         map(({ data }) => ({
           free: FN.fromInner(data.free.toString(), this.decimals),
-          locked: FN.fromInner(data.miscFrozen.toString(), this.decimals),
+          locked: FN.fromInner(data.frozen.toString(), this.decimals),
           reserved: FN.fromInner(data.reserved.toString(), this.decimals),
           available: FN.fromInner(
-            data.free.sub(data.miscFrozen).toString(),
+            data.free.sub(data.frozen).toString(),
             this.decimals
           ),
         }))

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -52,7 +52,7 @@ export const bifrostPolkadotRoutersConfig: Omit<
     token: "BNC",
     xcm: {
       // chopsticks test value: 48_800_000_000, add buffer
-      fee: { token: "BNC", amount: "50000000000" },
+      fee: { token: "BNC", amount: "500000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -116,7 +116,6 @@ class BifrostBalanceAdapter extends BalanceAdapter {
   ): Observable<BalanceData> {
     const storage = this.storages.balances(address);
 
-    console.log("inside subscribe balance");
     if (token === this.nativeToken) {
       return storage.observable.pipe(
         map(({ data }) => ({

--- a/src/adapters/bifrost.ts
+++ b/src/adapters/bifrost.ts
@@ -47,21 +47,34 @@ export const bifrostPolkadotRoutersConfig: Omit<
       weightLimit: DEST_WEIGHT,
     },
   },
+  {
+    to: "interlay",
+    token: "BNC",
+    xcm: {
+      // TODO: test in chopsticks
+      fee: { token: "BNC", amount: "50000000000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
 ];
 
 export const bifrostKusamaTokensConfig: Record<string, BasicToken> = {
+  BNC: { name: "BNC", symbol: "BNC", decimals: 12, ed: "10000000000" },
   VKSM: { name: "VKSM", symbol: "VKSM", decimals: 12, ed: "100000000" },
 };
 
 export const bifrostPolkadotTokensConfig: Record<string, BasicToken> = {
+  BNC: { name: "BNC", symbol: "BNC", decimals: 12, ed: "10000000000" },
   VDOT: { name: "VDOT", symbol: "VDOT", decimals: 10, ed: "1000000" },
 };
 
 const SUPPORTED_KUSAMA_TOKENS: Record<string, unknown> = {
+  BNC: { Native: "BNC" },
   VKSM: { VToken: "KSM" },
 };
 
 const SUPPORTED_POLKADOT_TOKENS: Record<string, unknown> = {
+  BNC: { Native: "BNC" },
   VDOT: { VToken2: 0 },
 };
 

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -124,6 +124,15 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
       weightLimit: DEST_WEIGHT,
     },
   },
+  {
+    to: "bifrost_polkadot",
+    token: "BNC",
+    xcm: {
+      // TODO: test in chopsticks, value below is from subscan x10
+      fee: { token: "BNC", amount: "5143680000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
 ];
 
 export const kintsugiRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
@@ -212,6 +221,7 @@ export const interlayTokensConfig: Record<
     USDC: { name: "USDC", symbol: "USDC", decimals: 6, ed: "0" },
     USDT: { name: "USDT", symbol: "USDT", decimals: 6, ed: "0" },
     VDOT: { name: "VDOT", symbol: "VDOT", decimals: 10, ed: "0" },
+    BNC: { name: "BNC", symbol: "BNC", decimals: 12, ed: "0" },
   },
   kintsugi: {
     KBTC: { name: "KBTC", symbol: "KBTC", decimals: 8, ed: "0" },
@@ -238,6 +248,7 @@ const INTERLAY_SUPPORTED_TOKENS: Record<string, unknown> = {
   INTR: { Token: "INTR" },
   USDT: { ForeignAsset: 2 },
   VDOT: { ForeignAsset: 3 },
+  BNC: { ForeignAsset: 11 },
   USDC: { ForeignAsset: 12 },
 };
 

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -128,8 +128,8 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "bifrost_polkadot",
     token: "BNC",
     xcm: {
-      // TODO: test in chopsticks, value below is from subscan x10
-      fee: { token: "BNC", amount: "5143680000" },
+      // chopsticks test value: 514_368_000, add buffer
+      fee: { token: "BNC", amount: "5000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },


### PR DESCRIPTION
This PR adds an XCM route for BNC between Bifrost and Interlay

:white_check_mark: Prerequisite: The [referendum to fix the asset registry location for BNC](https://interlay.subsquare.io/democracy/referenda/100) must pass and execute first.