### PR TITLE
Test: Update chopsticks version

### DIFF
--- a/.github/workflows/xcm-assethub-tests.yml
+++ b/.github/workflows/xcm-assethub-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Launch chopsticks
         timeout-minutes: 3
         run: |
-          npx --yes @acala-network/chopsticks@0.9.10 \
+          npx --yes @acala-network/chopsticks@0.10.1 \
             xcm \
             -r scripts/configs/kusama.yml \
             -p scripts/configs/kintsugi.yml \
@@ -55,7 +55,7 @@ jobs:
       - name: Launch chopsticks
         timeout-minutes: 3
         run: |
-          npx --yes @acala-network/chopsticks@0.9.10 \
+          npx --yes @acala-network/chopsticks@0.10.1 \
             xcm \
             -r scripts/configs/polkadot.yml \
             -p scripts/configs/interlay.yml \

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Launch chopsticks
         timeout-minutes: 3
         run: |
-          npx --yes @acala-network/chopsticks@0.9.10 \
+          npx --yes @acala-network/chopsticks@0.10.1 \
             xcm \
             -r scripts/configs/kusama.yml \
             -p scripts/configs/kintsugi.yml \
@@ -64,7 +64,7 @@ jobs:
       - name: Launch chopsticks
         timeout-minutes: 3
         run: |
-          npx --yes @acala-network/chopsticks@0.9.10 \
+          npx --yes @acala-network/chopsticks@0.10.1 \
             xcm \
             -r scripts/configs/polkadot.yml \
             -p scripts/configs/interlay.yml \

--- a/scripts/polkadot-chopsticks-assethub-test.ts
+++ b/scripts/polkadot-chopsticks-assethub-test.ts
@@ -34,6 +34,18 @@ async function main(): Promise<void> {
             from: "polkadot",
             to: "interlay",
         },
+        // USDC and USDC test cases broken since latest changes
+        // on statemint where those are converted to DOT before sending fees.
+        {
+            from: "interlay",
+            to: "statemint",
+            token: "USDC"
+        },
+        {
+            from: "interlay",
+            to: "statemint",
+            token: "USDT"
+        },
     ];
 
     await runTestCasesAndExit(adaptersEndpoints, true, skipCases);


### PR DESCRIPTION
- Bump chopsticks version from `0.9.10` to `0.10.1` to fix test errors.
- Disable broken test case when sending USDC or USDT from Interlay to AssetHub
  - AssetHub handling changed to converting those assets to DOT directly which seems to have broken our assertions. To be fixed as part of #194 