### PR TITLE
Feat: add Phala adapter for INTR and iBTC

### DIFF
--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -26,7 +26,6 @@ jobs:
             -r scripts/configs/kusama.yml \
             -p scripts/configs/kintsugi.yml \
             -p scripts/configs/karura.yml \
-            -p scripts/configs/parallel-heiko.yml \
             -p scripts/configs/bifrost.yml \
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."

--- a/.github/workflows/xcm-tests.yml
+++ b/.github/workflows/xcm-tests.yml
@@ -72,6 +72,7 @@ jobs:
             -p scripts/configs/acala.yml \
             -p scripts/configs/astar.yml \
             -p scripts/configs/bifrost-polkadot.yml \
+            -p scripts/configs/phala.yml \
             &> log.txt &
           echo "Waiting for log to show chopsticks is ready..."
           tail -f log.txt | grep -q "Connected parachains"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/bridge",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "polkawallet bridge sdk",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/scripts/configs/interlay.yml
+++ b/scripts/configs/interlay.yml
@@ -49,3 +49,8 @@ import-storage:
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, hdx
           - foreignAsset: 13
         - free: '1000000000000000'
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice, pha
+          - foreignAsset: 14
+        - free: '1000000000000000'

--- a/scripts/configs/phala.yml
+++ b/scripts/configs/phala.yml
@@ -1,0 +1,26 @@
+endpoint:
+  - wss://api.phala.network/ws
+  - wss://phala-rpc.dwellir.com
+mock-signature-host: true
+
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: '1000000000000000'
+  Assets:
+    Account:
+      -
+        -
+          - 14 # IBTC
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '1000000000000000'
+      -
+        -
+          - 13 # INTR
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - balance: '1000000000000000'

--- a/scripts/configs/phala.yml
+++ b/scripts/configs/phala.yml
@@ -12,6 +12,12 @@ import-storage:
         - providers: 1
           data:
             free: '1000000000000000'
+      -
+        -
+          - 5Eg2fntQS1bgCgPtXQ9Ysip6RUQkQJEMZqZ9u9qX6fcnhB4H # sibl 2032 (interlay sov)
+        - providers: 1
+          data:
+            free: '1000000000000000'
   Assets:
     Account:
       -

--- a/scripts/configs/phala.yml
+++ b/scripts/configs/phala.yml
@@ -11,13 +11,13 @@ import-storage:
           - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
         - providers: 1
           data:
-            free: '1000000000000000'
+            free: '100000000000000000'
       -
         -
           - 5Eg2fntQS1bgCgPtXQ9Ysip6RUQkQJEMZqZ9u9qX6fcnhB4H # sibl 2032 (interlay sov)
         - providers: 1
           data:
-            free: '1000000000000000'
+            free: '100000000000000000'
   Assets:
     Account:
       -

--- a/scripts/configs/statemine.yml
+++ b/scripts/configs/statemine.yml
@@ -1,5 +1,5 @@
 endpoint:
-  - wss://statemine-rpc.dwellir.com
+  - wss://asset-hub-kusama-rpc.dwellir.com
   - wss://rpc-asset-hub-kusama.luckyfriday.io
   - wss://statemine-rpc-tn.dwellir.com
   - wss://kusama-asset-hub-rpc.polkadot.io

--- a/scripts/configs/statemint.yml
+++ b/scripts/configs/statemint.yml
@@ -1,5 +1,5 @@
 endpoint:
-  - wss://statemint-rpc.dwellir.com
+  - wss://asset-hub-polkadot-rpc.dwellir.com
   - wss://rpc-asset-hub-polkadot.luckyfriday.io
   - wss://statemint-rpc-tn.dwellir.com
   - wss://polkadot-asset-hub-rpc.polkadot.io

--- a/scripts/interlay-chopsticks-test.ts
+++ b/scripts/interlay-chopsticks-test.ts
@@ -6,8 +6,8 @@ import { InterlayAdapter } from "../src/adapters/interlay";
 import { HydraAdapter } from "../src/adapters/hydradx";
 import { AcalaAdapter } from "../src/adapters/acala";
 import { AstarAdapter } from "../src/adapters/astar";
-// import { ParallelAdapter } from "../src/adapters/parallel";
 import { BifrostPolkadotAdapter } from "../src/adapters/bifrost";
+import { PhalaAdapter } from "../src/adapters/phala";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
 import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";
 
@@ -27,9 +27,9 @@ async function main(): Promise<void> {
         hydra: { adapter: new HydraAdapter(), endpoints: ['ws://127.0.0.1:8001'] },
         acala: { adapter: new AcalaAdapter(), endpoints: ['ws://127.0.0.1:8002'] },
         astar: { adapter: new AstarAdapter(), endpoints: ['ws://127.0.0.1:8003'] },
-        // parallel: { adapter: new ParallelAdapter(), endpoints: ['ws://127.0.0.1:8004'] },
         bifrost_polkadot: { adapter: new BifrostPolkadotAdapter(), endpoints: ['ws://127.0.0.1:8004']},
-        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8005'] },
+        phala: { adapter: new PhalaAdapter(), endpoints: ['ws://127.0.0.1:8005']},
+        polkadot: { adapter: new PolkadotAdapter(), endpoints: ['ws://127.0.0.1:8006'] },
     };
 
     const skipCases: Partial<RouterTestCase>[] = [

--- a/scripts/kintsugi-chopsticks-test.ts
+++ b/scripts/kintsugi-chopsticks-test.ts
@@ -4,7 +4,7 @@
 import { KaruraAdapter } from "../src/adapters/acala";
 import { BifrostKusamaAdapter } from "../src/adapters/bifrost";
 import { KintsugiAdapter } from "../src/adapters/interlay";
-import { HeikoAdapter } from "../src/adapters/parallel";
+// import { HeikoAdapter } from "../src/adapters/parallel";
 import { KusamaAdapter } from "../src/adapters/polkadot";
 import { BaseCrossChainAdapter } from "../src/base-chain-adapter";
 import { RouterTestCase, runTestCasesAndExit } from "./chopsticks-test";

--- a/scripts/kintsugi-chopsticks-test.ts
+++ b/scripts/kintsugi-chopsticks-test.ts
@@ -23,9 +23,9 @@ async function main(): Promise<void> {
         //           relaychain gets its port last after all parachains.
         kintsugi:   { adapter: new KintsugiAdapter(),   endpoints: ['ws://127.0.0.1:8000'] },
         karura:     { adapter: new KaruraAdapter(),     endpoints: ['ws://127.0.0.1:8001'] },
-        heiko:      { adapter: new HeikoAdapter(),      endpoints: ['ws://127.0.0.1:8002'] },
-        bifrost:    { adapter: new BifrostKusamaAdapter(),    endpoints: ['ws://127.0.0.1:8003'] },
-        kusama:     { adapter: new KusamaAdapter(),     endpoints: ['ws://127.0.0.1:8004'] },
+        // heiko:      { adapter: new HeikoAdapter(),      endpoints: ['ws://127.0.0.1:8002'] },
+        bifrost:    { adapter: new BifrostKusamaAdapter(),    endpoints: ['ws://127.0.0.1:8002'] },
+        kusama:     { adapter: new KusamaAdapter(),     endpoints: ['ws://127.0.0.1:8003'] },
     };
 
     const skipCases: Partial<RouterTestCase>[] = [

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -66,6 +66,21 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     xcm: { fee: { token: "IBTC", amount: "1030" }, weightLimit: DEST_WEIGHT },
   },
   {
+    to: "phala",
+    token: "INTR",
+    xcm: {
+      // TODO: get chopsticks test data: fee = 6_535_947_712 Add 10x margin
+      fee: { token: "INTR", amount: "65359477120" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "phala",
+    token: "IBTC",
+    // TODO: get chopsticks test: fee = 103 Add 10x margin
+    xcm: { fee: { token: "IBTC", amount: "1030" }, weightLimit: DEST_WEIGHT },
+  },
+  {
     to: "polkadot",
     token: "DOT",
     xcm: {

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -86,8 +86,11 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {
     to: "phala",
     token: "IBTC",
-    // chopsticks test: fee = 6429600. Add ~3x margin
-    xcm: { fee: { token: "IBTC", amount: "20000000" }, weightLimit: DEST_WEIGHT },
+    xcm: {
+      // chopsticks test: fee = 6429600. Add ~3x margin
+      fee: { token: "IBTC", amount: "20000000" },
+      weightLimit: DEST_WEIGHT
+    },
   },
   {
     to: "polkadot",

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -69,8 +69,8 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "phala",
     token: "PHA",
     xcm: {
-      // chopsticks test data: 2_810_000_095, use ~10x buffer
-      fee: { token: "PHA", amount: "28000000000" },
+      // chopsticks test data: 64_296_000_000, use ~2.5x buffer
+      fee: { token: "PHA", amount: "150000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -69,8 +69,8 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "phala",
     token: "PHA",
     xcm: {
-      // TODO: get chopsticks test data
-      fee: { token: "PHA", amount: "101200000000" },
+      // chopsticks test data: 2_810_000_095, use ~10x buffer
+      fee: { token: "PHA", amount: "28000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },
@@ -78,8 +78,8 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "phala",
     token: "INTR",
     xcm: {
-      // TODO: get chopsticks test data: fee = 6_535_947_712 Add 10x margin
-      fee: { token: "INTR", amount: "65359477120" },
+      // chopsticks test data: fee = 642_960_000, use ~10x buffer
+      fee: { token: "INTR", amount: "6400000000" },
       weightLimit: DEST_WEIGHT,
     },
   },
@@ -87,7 +87,7 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "phala",
     token: "IBTC",
     xcm: {
-      // chopsticks test: fee = 6429600. Add ~3x margin
+      // chopsticks test: fee = 6429600. Use ~3x buffer
       fee: { token: "IBTC", amount: "20000000" },
       weightLimit: DEST_WEIGHT
     },

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -67,6 +67,15 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   },
   {
     to: "phala",
+    token: "PHA",
+    xcm: {
+      // TODO: get chopsticks test data
+      fee: { token: "PHA", amount: "51200000000" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "phala",
     token: "INTR",
     xcm: {
       // TODO: get chopsticks test data: fee = 6_535_947_712 Add 10x margin
@@ -247,6 +256,7 @@ export const interlayTokensConfig: Record<
     VDOT: { name: "VDOT", symbol: "VDOT", decimals: 10, ed: "0" },
     BNC: { name: "BNC", symbol: "BNC", decimals: 12, ed: "0" },
     HDX: { name: "HDX", symbol: "HDX", decimals: 12, ed: "0" },
+    PHA: { name: "PHA", symbol: "PHA", decimals: 12, ed: "10000000000" },
   },
   kintsugi: {
     KBTC: { name: "KBTC", symbol: "KBTC", decimals: 8, ed: "0" },
@@ -276,6 +286,7 @@ const INTERLAY_SUPPORTED_TOKENS: Record<string, unknown> = {
   BNC: { ForeignAsset: 11 },
   USDC: { ForeignAsset: 12 },
   HDX: { ForeignAsset: 13 },
+  PHA: { ForeignAsset: 14 },
 };
 
 const getSupportedTokens = (chainname: string): Record<string, unknown> => {

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -89,7 +89,7 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     xcm: {
       // chopsticks test: fee = 6429600. Use ~3x buffer
       fee: { token: "IBTC", amount: "20000000" },
-      weightLimit: DEST_WEIGHT
+      weightLimit: DEST_WEIGHT,
     },
   },
   {

--- a/src/adapters/interlay.ts
+++ b/src/adapters/interlay.ts
@@ -70,7 +70,7 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     token: "PHA",
     xcm: {
       // TODO: get chopsticks test data
-      fee: { token: "PHA", amount: "51200000000" },
+      fee: { token: "PHA", amount: "101200000000" },
       weightLimit: DEST_WEIGHT,
     },
   },
@@ -86,8 +86,8 @@ export const interlayRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {
     to: "phala",
     token: "IBTC",
-    // TODO: get chopsticks test: fee = 103 Add 10x margin
-    xcm: { fee: { token: "IBTC", amount: "1030" }, weightLimit: DEST_WEIGHT },
+    // chopsticks test: fee = 6429600. Add ~3x margin
+    xcm: { fee: { token: "IBTC", amount: "20000000" }, weightLimit: DEST_WEIGHT },
   },
   {
     to: "polkadot",

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -25,8 +25,8 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "interlay",
     token: "PHA",
     xcm: {
-      // TODO: confirm via chopsticks test, best guess: 8_000_0000_000_000
-      fee: { token: "PHA", amount: "5000000000000000" },
+      // chopsticks test: fees 78_600_800_000_000, use a small buffer (too expensive to use a standard buffer)
+      fee: { token: "PHA", amount: "100000000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -26,7 +26,7 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     token: "PHA",
     xcm: {
       // TODO: confirm via chopsticks test
-      fee: { token: "PHA", amount: "216604720" },
+      fee: { token: "PHA", amount: "1016604720" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -23,6 +23,15 @@ type TokenData = ExtendedToken & { toQuery: () => string };
 export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   {
     to: "interlay",
+    token: "PHA",
+    xcm: {
+      // TODO: confirm via chopsticks test
+      fee: { token: "PHA", amount: "216604720" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "interlay",
     token: "IBTC",
     xcm: {
       // during chopsticks test: fee = 71 Add 10x margin
@@ -54,7 +63,7 @@ export const phalaTokensConfig: Record<string, Record<string, TokenData>> = {
       name: "IBTC",
       symbol: "IBTC",
       decimals: 8,
-      ed: "1,000,000",
+      ed: "1000000",
       toRaw: () =>
         "0x0001000000000000000000000000000000000000000000000000000000000000",
       toQuery: () => "14",
@@ -63,7 +72,7 @@ export const phalaTokensConfig: Record<string, Record<string, TokenData>> = {
       name: "INTR",
       symbol: "INTR",
       decimals: 10,
-      ed: "100,000,000",
+      ed: "100000000",
       toRaw: () =>
         "0x0002000000000000000000000000000000000000000000000000000000000000",
       toQuery: () => "13",

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -1,0 +1,281 @@
+import { Storage } from "@acala-network/sdk/utils/storage";
+import { AnyApi, FixedPointNumber as FN } from "@acala-network/sdk-core";
+import { combineLatest, map, Observable } from "rxjs";
+
+import { SubmittableExtrinsic } from "@polkadot/api/types";
+import { DeriveBalancesAll } from "@polkadot/api-derive/balances/types";
+import { ISubmittableResult } from "@polkadot/types/types";
+
+import { BalanceAdapter, BalanceAdapterConfigs } from "../balance-adapter";
+import { BaseCrossChainAdapter } from "../base-chain-adapter";
+import { ChainName, chains } from "../configs";
+import { ApiNotFound, CurrencyNotFound } from "../errors";
+import {
+  BalanceData,
+  CrossChainRouterConfigs,
+  CrossChainTransferParams,
+  ExtendedToken,
+} from "../types";
+
+const DEST_WEIGHT = "Unlimited";
+type TokenData = ExtendedToken & { toQuery: () => string };
+
+export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
+  {
+    to: "interlay",
+    token: "IBTC",
+    xcm: {
+      // during chopsticks test: fee = 71 Add 10x margin
+      fee: { token: "IBTC", amount: "710" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+  {
+    to: "interlay",
+    token: "INTR",
+    xcm: {
+      // during chopsticks test: fee = 21_660_472 Add 10x margin
+      fee: { token: "INTR", amount: "216604720" },
+      weightLimit: DEST_WEIGHT,
+    },
+  },
+];
+
+export const phalaTokensConfig: Record<
+  string,
+  Record<string, TokenData>
+> = {
+  phala: {
+    PHA: {
+      name: "PHA",
+      symbol: "PHA",
+      decimals: 12,
+      ed: "10000000000",
+    } as TokenData,
+    // ed confirmed via assets.asset(<id>)
+    IBTC: {
+      name: "IBTC",
+      symbol: "IBTC",
+      decimals: 8,
+      ed: "1,000,000",
+      toRaw: () =>
+        "0x0001000000000000000000000000000000000000000000000000000000000000",
+      toQuery: () => "14",
+    },
+    INTR: {
+      name: "INTR",
+      symbol: "INTR",
+      decimals: 10,
+      ed: "100,000,000",
+      toRaw: () =>
+        "0x0002000000000000000000000000000000000000000000000000000000000000",
+      toQuery: () => "13",
+    },
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const createBalanceStorages = (api: AnyApi) => {
+  return {
+    balances: (address: string) =>
+      Storage.create<DeriveBalancesAll>({
+        api,
+        path: "derive.balances.all",
+        params: [address],
+      }),
+    assets: (tokenId: string, address: string) =>
+      Storage.create<any>({
+        api,
+        path: "query.assets.account",
+        params: [tokenId, address],
+      }),
+  };
+};
+
+class PhalaBalanceAdapter extends BalanceAdapter {
+  private storages: ReturnType<typeof createBalanceStorages>;
+
+  constructor({ api, chain, tokens }: BalanceAdapterConfigs) {
+    super({ api, chain, tokens });
+    this.storages = createBalanceStorages(api);
+  }
+
+  public subscribeBalance(
+    token: string,
+    address: string
+  ): Observable<BalanceData> {
+    const storage = this.storages.balances(address);
+
+    if (token === this.nativeToken) {
+      return storage.observable.pipe(
+        map((data) => ({
+          free: FN.fromInner(data.freeBalance.toString(), this.decimals),
+          locked: FN.fromInner(data.lockedBalance.toString(), this.decimals),
+          reserved: FN.fromInner(
+            data.reservedBalance.toString(),
+            this.decimals
+          ),
+          available: FN.fromInner(
+            data.availableBalance.toString(),
+            this.decimals
+          ),
+        }))
+      );
+    }
+
+    const tokenData: TokenData = this.getToken(token);
+
+    if (!tokenData) {
+      throw new CurrencyNotFound(token);
+    }
+
+    return this.storages.assets(tokenData.toQuery(), address).observable.pipe(
+      map((balance) => {
+        const amount = FN.fromInner(
+          balance.unwrapOrDefault()?.balance?.toString() || "0",
+          this.getToken(token).decimals
+        );
+
+        return {
+          free: amount,
+          locked: new FN(0),
+          reserved: new FN(0),
+          available: amount,
+        };
+      })
+    );
+  }
+}
+
+class BasePhalaAdapter extends BaseCrossChainAdapter {
+  private balanceAdapter?: PhalaBalanceAdapter;
+
+  public override async setApi(api: AnyApi) {
+    this.api = api;
+
+    await api.isReady;
+
+    const chain = this.chain.id as ChainName;
+
+    this.balanceAdapter = new PhalaBalanceAdapter({
+      chain,
+      api,
+      tokens: phalaTokensConfig[chain],
+    });
+  }
+
+  public subscribeTokenBalance(
+    token: string,
+    address: string
+  ): Observable<BalanceData> {
+    if (!this.balanceAdapter) {
+      throw new ApiNotFound(this.chain.id);
+    }
+
+    return this.balanceAdapter.subscribeBalance(token, address);
+  }
+
+  public subscribeMaxInput(
+    token: string,
+    address: string,
+    to: ChainName
+  ): Observable<FN> {
+    if (!this.balanceAdapter) {
+      throw new ApiNotFound(this.chain.id);
+    }
+
+    return combineLatest({
+      txFee:
+        token === this.balanceAdapter?.nativeToken
+          ? this.estimateTxFee({
+              amount: FN.ZERO,
+              to,
+              token,
+              address,
+              signer: address,
+            })
+          : "0",
+      balance: this.balanceAdapter
+        .subscribeBalance(token, address)
+        .pipe(map((i) => i.available)),
+    }).pipe(
+      map(({ balance, txFee }) => {
+        const tokenMeta = this.balanceAdapter?.getToken(token);
+        const feeFactor = 1.2;
+        const fee = FN.fromInner(txFee, tokenMeta?.decimals).mul(
+          new FN(feeFactor)
+        );
+
+        // always minus ed
+        return balance
+          .minus(fee)
+          .minus(FN.fromInner(tokenMeta?.ed || "0", tokenMeta?.decimals));
+      })
+    );
+  }
+
+  public createTx(
+    params: CrossChainTransferParams
+  ):
+    | SubmittableExtrinsic<"promise", ISubmittableResult>
+    | SubmittableExtrinsic<"rxjs", ISubmittableResult> {
+    if (!this.api) {
+      throw new ApiNotFound(this.chain.id);
+    }
+
+    const { address, amount, to, token } = params;
+
+    const accountId = this.api?.createType("AccountId32", address).toHex();
+    const toChain = chains[to];
+
+    const dst = {
+      parents: 1,
+      interior: {
+        X2: [
+          { Parachain: toChain.paraChainId },
+          { AccountId32: { id: accountId } },
+        ],
+      },
+    };
+
+    let asset: any = {
+      id: { Concrete: { parents: 0, interior: "Here" } },
+      fun: { Fungible: amount.toChainData() },
+    };
+
+    const tokenData: TokenData = this.getToken(token);
+
+    if (!tokenData) {
+      throw new CurrencyNotFound(token);
+    }
+
+    if (token !== this.balanceAdapter?.nativeToken) {
+      asset = {
+        id: {
+          Concrete: {
+            parents: 1,
+            interior: {
+              X2: [
+                { Parachain: toChain.paraChainId },
+                { GeneralKey: { length: 2, data: tokenData.toRaw() } },
+              ],
+            },
+          },
+        },
+        fun: { Fungible: amount.toChainData() },
+      };
+    }
+
+    return this.api.tx.xTransfer.transfer(asset, dst, undefined);
+  }
+}
+
+export class PhalaAdapter extends BasePhalaAdapter {
+  constructor() {
+    super(
+      chains.phala,
+      phalaRoutersConfig,
+      phalaTokensConfig.parallel
+    );
+  }
+}

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -25,8 +25,8 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "interlay",
     token: "PHA",
     xcm: {
-      // TODO: confirm via chopsticks test
-      fee: { token: "PHA", amount: "1016604720" },
+      // TODO: confirm via chopsticks test, best guess: 8_000_0000_000_000
+      fee: { token: "PHA", amount: "5000000000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },
@@ -34,8 +34,8 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "interlay",
     token: "IBTC",
     xcm: {
-      // during chopsticks test: fee = 71 Add 10x margin
-      fee: { token: "IBTC", amount: "710" },
+      // during chopsticks test: fee = 63, use ~10x buffer
+      fee: { token: "IBTC", amount: "600" },
       weightLimit: DEST_WEIGHT,
     },
   },
@@ -43,8 +43,8 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     to: "interlay",
     token: "INTR",
     xcm: {
-      // during chopsticks test: fee = 21_660_472 Add 10x margin
-      fee: { token: "INTR", amount: "216604720" },
+      // during chopsticks test: fee = 19_213_457, use ~10x buffer
+      fee: { token: "INTR", amount: "200000000" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -26,7 +26,7 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
     token: "PHA",
     xcm: {
       // chopsticks test: fees 78_600_800_000_000, use a small buffer (too expensive to use a standard buffer)
-      fee: { token: "PHA", amount: "100000000000000" },
+      fee: { token: "PHA", amount: "120000000000000" },
       weightLimit: DEST_WEIGHT,
     },
   },

--- a/src/adapters/phala.ts
+++ b/src/adapters/phala.ts
@@ -41,10 +41,7 @@ export const phalaRoutersConfig: Omit<CrossChainRouterConfigs, "from">[] = [
   },
 ];
 
-export const phalaTokensConfig: Record<
-  string,
-  Record<string, TokenData>
-> = {
+export const phalaTokensConfig: Record<string, Record<string, TokenData>> = {
   phala: {
     PHA: {
       name: "PHA",
@@ -272,10 +269,6 @@ class BasePhalaAdapter extends BaseCrossChainAdapter {
 
 export class PhalaAdapter extends BasePhalaAdapter {
   constructor() {
-    super(
-      chains.phala,
-      phalaRoutersConfig,
-      phalaTokensConfig.parallel
-    );
+    super(chains.phala, phalaRoutersConfig, phalaTokensConfig.phala);
   }
 }

--- a/src/bridge.spec.ts
+++ b/src/bridge.spec.ts
@@ -13,6 +13,7 @@ import { AcalaAdapter, KaruraAdapter } from "./adapters/acala";
 import { BifrostKusamaAdapter, BifrostPolkadotAdapter } from "./adapters/bifrost";
 import { HydraAdapter } from "./adapters/hydradx";
 import { AstarAdapter } from "./adapters/astar";
+import { PhalaAdapter } from "./adapters/phala";
 
 describe.skip("Bridge sdk usage", () => {
   jest.setTimeout(30000);
@@ -34,6 +35,7 @@ describe.skip("Bridge sdk usage", () => {
     hydra: new HydraAdapter(),
     parallel: new ParallelAdapter(),
     astar: new AstarAdapter(),
+    phala: new PhalaAdapter(),
   };
 
   const bridge = new Bridge({
@@ -183,6 +185,9 @@ describe.skip("Bridge sdk usage", () => {
 
     // interlay
     // printBidirectionalTxs("interlay", "polkadot", "DOT");
+    printBidirectionalTxs("interlay", "phala", "PHA");
+    printBidirectionalTxs("interlay", "phala", "INTR");
+    printBidirectionalTxs("interlay", "phala", "IBTC");
     // printBidirectionalTxs("interlay", "statemint", "USDT");
     // printBidirectionalTxs("interlay", "hydra", "IBTC");
     // printBidirectionalTxs("interlay", "hydra", "INTR");
@@ -192,11 +197,11 @@ describe.skip("Bridge sdk usage", () => {
     // printBidirectionalTxs("interlay", "parallel", "IBTC");
     // printBidirectionalTxs("interlay", "astar", "INTR");
     // printBidirectionalTxs("interlay", "astar", "IBTC");
-    printBidirectionalTxs("interlay", "bifrost_polkadot", "VDOT");
+    // printBidirectionalTxs("interlay", "bifrost_polkadot", "VDOT");
     // printBidirectionalTxs("polkadot", "statemint", "DOT");
   });
 
-  test("5. getNativeToken should work", () => {
+  test.skip("5. getNativeToken should work", () => {
     const testCases: [ChainName, String][] = [
       // kusama network
       ["kusama", "KSM"],
@@ -213,6 +218,7 @@ describe.skip("Bridge sdk usage", () => {
       ["parallel", "PARA"],
       ["bifrost_polkadot", "BNC"],
       ["statemint", "DOT"],
+      ["phala", "PHA"],
     ];
 
     for (const [chainName, expectedNativeToken] of testCases) {

--- a/src/configs/chains/polkadot-chains.ts
+++ b/src/configs/chains/polkadot-chains.ts
@@ -77,4 +77,12 @@ export const polkadotChains = {
     paraChainId: 2034,
     ss58Prefix: 63,
   },
+  phala: {
+    id: "phala",
+    display: "Phala",
+    type: typeSubstrate,
+    icon: "",
+    paraChainId: 2035,
+    ss58Prefix: 30,
+  },
 };


### PR DESCRIPTION
TODO:
- [x] complete local manual XCM tests
- [x] fix broken chopsticks tests for Phala
- [x] confirm fee estimate amounts in local tests

Notes / additional changes:
- deactivated Parallel Heiko tests; their only wss endpoint is unresponsive for extended periods of time
- implemented lower than usual fee overestimation factor config, and checks in tests for PHA as xcm costs are very high